### PR TITLE
Prisma studio new port

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,7 +5,7 @@
   "types": "./index.ts",
   "license": "MIT",
   "scripts": {
-    "dev": "prisma studio",
+    "dev": "prisma studio --port 5000", 
     "db-push": "prisma db push",
     "postinstall": "prisma generate"
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,7 +5,7 @@
   "types": "./index.ts",
   "license": "MIT",
   "scripts": {
-    "dev": "prisma studio --port 5000", 
+    "dev": "prisma studio --port 5556", 
     "db-push": "prisma db push",
     "postinstall": "prisma generate"
   },


### PR DESCRIPTION
Both Android Studio and Prisma run on port: 5555 by default, so I assigned Prisma Studio to run on 5556 to avoid conflict.

Originally suggested 5000 but changed to 5556 due to a known issue of port 5000 not being available on some Macs.