### PR TITLE
fix: use Expo default metro config and configure monorepo

### DIFF
--- a/apps/expo/metro.config.js
+++ b/apps/expo/metro.config.js
@@ -1,6 +1,24 @@
-module.exports = {
-  resolver: {
-    /* resolver options */
-    sourceExts: ["jsx", "js", "ts", "tsx", "cjs"],
-  },
-};
+// Learn more: https://docs.expo.dev/guides/monorepos/
+const { getDefaultConfig } = require('expo/metro-config');
+const path = require('path');
+
+const projectRoot = __dirname;
+const workspaceRoot = path.resolve(projectRoot, '../..');
+
+// Create the default Metro config
+const config = getDefaultConfig(projectRoot);
+
+// Add the additional `cjs` extension to the resolver
+config.resolver.sourceExts.push('cjs');
+
+// 1. Watch all files within the monorepo
+config.watchFolders = [workspaceRoot];
+// 2. Let Metro know where to resolve packages and in what order
+config.resolver.nodeModulesPaths = [
+  path.resolve(projectRoot, 'node_modules'),
+  path.resolve(workspaceRoot, 'node_modules'),
+];
+// 3. Force Metro to resolve (sub)dependencies only from the `nodeModulesPaths`
+config.resolver.disableHierarchicalLookup = true;
+
+module.exports = config;


### PR DESCRIPTION
There are two things here:

1. The Expo defaults for Metro were overwritten with `module.exports = { (new object) };`. It's better to use the `expo/metro-config` and change the config object from `getDefaultConfig`. This includes the defaults we carefully put together to get the most out of Metro and helps you safe guard against future big Metro changes.

2. Metro wasn't configured for monorepo usage, which likely leads to unexpected errors later on. With this config, you should be able to use pretty much any package manager or monorepo tool. ([like pnpm with turborepo](https://github.com/byCedric/expo-monorepo-example#readme) 😄)