### PR TITLE
fix: rename expo entry file

### DIFF
--- a/apps/expo/index.ts
+++ b/apps/expo/index.ts
@@ -1,0 +1,8 @@
+import { registerRootComponent } from "expo";
+
+import App from "./src/_app";
+
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in Expo Go or in a native build,
+// the environment is set up appropriately
+registerRootComponent(App);

--- a/apps/expo/index.ts
+++ b/apps/expo/index.ts
@@ -1,6 +1,6 @@
 import { registerRootComponent } from "expo";
 
-import App from "./src/_app";
+import { App } from "./src/_app";
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@acme/expo",
   "version": "0.1.0",
-  "main": "src/_app.tsx",
+  "main": "index.ts",
   "scripts": {
     "start": "expo start",
     "dev": "expo start --ios",

--- a/apps/expo/src/_app.tsx
+++ b/apps/expo/src/_app.tsx
@@ -5,7 +5,7 @@ import { TRPCProvider } from "./utils/trpc";
 
 import { HomeScreen } from "./screens/home";
 
-const App = () => {
+export const App = () => {
   return (
     <TRPCProvider>
       <SafeAreaProvider>
@@ -15,4 +15,3 @@ const App = () => {
     </TRPCProvider>
   );
 };
-

--- a/apps/expo/src/_app.tsx
+++ b/apps/expo/src/_app.tsx
@@ -1,4 +1,3 @@
-import { registerRootComponent } from "expo";
 import { StatusBar } from "expo-status-bar";
 import React from "react";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -17,4 +16,4 @@ const App = () => {
   );
 };
 
-registerRootComponent(App);
+export default App;

--- a/apps/expo/src/_app.tsx
+++ b/apps/expo/src/_app.tsx
@@ -16,4 +16,3 @@ const App = () => {
   );
 };
 
-export default App;


### PR DESCRIPTION
this is a fix for the issue i was having in #31 

it seems that the entry point for expo needs to be index.*

so i've renamed and moved the file up out of the src folder into the root.

`npx expo run:ios` now works, notice the index.tsx loading bar, this was not there previously as index was not found...

now we are getting the expected localhost error

![Screenshot 2022-10-12 at 19 07 25](https://user-images.githubusercontent.com/47508642/195416979-39cac926-c685-4c93-9764-92581c62860a.png)
![Screenshot 2022-10-12 at 19 18 38](https://user-images.githubusercontent.com/47508642/195418397-19b03cab-09ac-44bd-8a85-c59ffbe42f7d.png)
