### PR TITLE
fix: make build/dev depend on db-generate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ on:
 
 # You can leverage Vercel Remote Caching with Turbo to speed up your builds
 # @link https://turborepo.org/docs/core-concepts/remote-caching#remote-caching-on-vercel-builds
-# env:
-#   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-#   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   build-lint:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "turbo build",
     "dev": "turbo dev --parallel",
     "clean:workspaces": "turbo clean",
-    "clean": "rm -rf node_modules",
+    "clean": "rm -rf node_modules .turbo .vercel",
     "lint": "turbo lint && manypkg check",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "db-push": "turbo db-push",
     "build": "turbo build",
     "dev": "turbo dev --parallel",
-    "cleen": "turbo clean",
+    "clean:workspaces": "turbo clean",
     "clean": "rm -rf node_modules",
     "lint": "turbo lint && manypkg check",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "packageManager": "pnpm@7.13.0",
   "scripts": {
-    "postinstall": "turbo postinstall",
-    "db-push": "pnpm --filter @acme/db db-push",
+    "db-generate": "turbo db-generate",
+    "db-push": "turbo db-push",
     "build": "turbo build",
     "dev": "turbo dev --parallel",
     "cleen": "turbo clean",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -8,7 +8,7 @@
     "dev": "prisma studio --port 5556",
     "clean": "rm -rf .turbo node_modules",
     "db-push": "prisma db push",
-    "postinstall": "prisma generate"
+    "db-generate": "prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^4.4.0"

--- a/turbo.json
+++ b/turbo.json
@@ -1,17 +1,19 @@
 {
   "pipeline": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "db-generate"],
       "outputs": [".next/**", ".expo/**"]
     },
     "lint": {
       "outputs": []
     },
     "dev": {
+      "dependsOn": ["db-generate"],
       "cache": false
     },
+    "db-generate": {},
+    "db-push": {},
     "clean": {},
-    "//#clean": {},
-    "postinstall": {}
+    "//#clean": {}
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,14 +1,14 @@
 {
   "pipeline": {
     "build": {
-      "dependsOn": ["^build", "db-generate"],
+      "dependsOn": ["^build", "^db-generate"],
       "outputs": [".next/**", ".expo/**"]
     },
     "lint": {
       "outputs": []
     },
     "dev": {
-      "dependsOn": ["db-generate"],
+      "dependsOn": ["^db-generate"],
       "cache": false
     },
     "db-generate": {},

--- a/turbo.json
+++ b/turbo.json
@@ -11,9 +11,17 @@
       "dependsOn": ["^db-generate"],
       "cache": false
     },
-    "db-generate": {},
-    "db-push": {},
-    "clean": {},
-    "//#clean": {}
+    "db-generate": {
+      "cache": false
+    },
+    "db-push": {
+      "cache": false
+    },
+    "clean": {
+      "cache": false
+    },
+    "//#clean": {
+      "cache": false
+    }
   }
 }


### PR DESCRIPTION
Dont `prisma generate` on postinstall, but instead make build/dev depend on it.

Ref: https://twitter.com/mattpocockuk/status/1582660272330018816