### PR TITLE
Prevent creation of multiple prisma clients

### DIFF
--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -1,23 +1,19 @@
 import { PrismaClient } from "./.generated/client";
 
-let prisma: PrismaClient;
-if (process.env.NODE_ENV === "production") {
-  prisma = new PrismaClient({
-    log: ["query"],
-  });
-  console.log("Production: Created DB connection.");
-} else {
-  // @ts-ignore
-  if (!global.prisma) {
-    // @ts-ignore
-    global.prisma = new PrismaClient({
-      log: ["query"],
-    });
-    console.log("Development: Created DB connection.");
-  }
-
-  // @ts-ignore
-  prisma = global.prisma;
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
 }
 
-export { prisma };
+export const prisma =
+  global.prisma ||
+  new PrismaClient({
+    log:
+      process.env.NODE_ENV === "development"
+        ? ["query", "error", "warn"]
+        : ["error"],
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  global.prisma = prisma;
+}

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -1,5 +1,23 @@
 import { PrismaClient } from "./.generated/client";
 
-export const prisma = new PrismaClient({
-  log: ["query"],
-});
+let prisma: PrismaClient;
+if (process.env.NODE_ENV === "production") {
+  prisma = new PrismaClient({
+    log: ["query"],
+  });
+  console.log("Production: Created DB connection.");
+} else {
+  // @ts-ignore
+  if (!global.prisma) {
+    // @ts-ignore
+    global.prisma = new PrismaClient({
+      log: ["query"],
+    });
+    console.log("Development: Created DB connection.");
+  }
+
+  // @ts-ignore
+  prisma = global.prisma;
+}
+
+export { prisma };


### PR DESCRIPTION
After running into issues with the prisma client creating multiple connections, I did some digging and found that it's a [common problem with next](https://www.prisma.io/docs/guides/database/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices). 

This PR uses a section of code from [this issue](https://github.com/prisma/prisma/issues/5007#issuecomment-740803749) to resolve the problem by preventing the client from being recreated.

Quick note: I didn't clone this repo when starting my project, I followed the article on migrating an existing t3 app. If there is already a fix for this somewhere that I missed, my bad.