### PR TITLE
Revert "Generate prisma client outside of node modules, cache generated client"

### DIFF
--- a/packages/db/.gitignore
+++ b/packages/db/.gitignore
@@ -1,1 +1,0 @@
-.generated/*

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "./.generated/client";
+import { PrismaClient } from "@prisma/client";
 
 export const prisma = new PrismaClient({
   log: ["query"],

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3,7 +3,6 @@
 
 generator client {
     provider = "prisma-client-js"
-    output   = "../.generated/client"
 }
 
 datasource db {

--- a/turbo.json
+++ b/turbo.json
@@ -1,8 +1,5 @@
 {
   "pipeline": {
-    "db-generate": {
-      "outputs": [".generated/**"]
-    },
     "build": {
       "dependsOn": ["^build", "^db-generate"],
       "outputs": [".next/**", ".expo/**"]
@@ -12,6 +9,9 @@
     },
     "dev": {
       "dependsOn": ["^db-generate"],
+      "cache": false
+    },
+    "db-generate": {
       "cache": false
     },
     "db-push": {


### PR DESCRIPTION
Reverts t3-oss/create-t3-turbo#37

Because https://github.com/t3-oss/create-t3-turbo/issues/42