### PR TITLE
Restore "Generate prisma client outside of node modules, cache generated client"

### DIFF
--- a/packages/db/.gitignore
+++ b/packages/db/.gitignore
@@ -1,0 +1,1 @@
+.generated/*

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "./.generated/client";
 
 export const prisma = new PrismaClient({
   log: ["query"],

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3,6 +3,7 @@
 
 generator client {
     provider = "prisma-client-js"
+    output   = "../.generated/client"
 }
 
 datasource db {

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,8 @@
 {
   "pipeline": {
+    "db-generate": {
+      "outputs": [".generated/**"]
+    },
     "build": {
       "dependsOn": ["^build", "^db-generate"],
       "outputs": [".next/**", ".expo/**"]
@@ -9,9 +12,6 @@
     },
     "dev": {
       "dependsOn": ["^db-generate"],
-      "cache": false
-    },
-    "db-generate": {
       "cache": false
     },
     "db-push": {


### PR DESCRIPTION
un-reverts t3-oss/create-t3-turbo#37

First we should fix https://github.com/t3-oss/create-t3-turbo/issues/42