### PR TITLE
Enable Prisma Client caching by Turbo and hoist Client artifacts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,4 @@
 # The symbolic links of pnpm break the rules of Expo monorepos.
 # @link https://docs.expo.dev/guides/monorepos/#common-issues
 node-linker=hoisted
+public-hoist-pattern[]=*prisma*

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from "@prisma/client";
 
 declare global {
   // allow global `var` declarations

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -15,6 +15,6 @@ export const prisma =
         : ["error"],
   });
 
-if (process.env.NODE_ENV !== "production") global.prisma = prisma;
-
-export type { PrismaClient };
+if (process.env.NODE_ENV !== "production") {
+  global.prisma = prisma;
+}

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -1,5 +1,17 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from '@prisma/client';
 
-export const prisma = new PrismaClient({
-  log: ["query"],
-});
+declare global {
+  // allow global `var` declarations
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
+}
+
+export const prisma =
+  global.prisma ||
+  new PrismaClient({
+    log: ['query'],
+  });
+
+if (process.env.NODE_ENV !== 'production') global.prisma = prisma;
+
+export type { PrismaClient };

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,7 @@
       "cache": false
     },
     "db-generate": {
-      "cache": false
+      "cache": true 
     },
     "db-push": {
       "cache": false


### PR DESCRIPTION
This PR addresses the error `warn(prisma-client) There are already 10 instances of Prisma Client actively running` when adding Prisma to Next.js, as recommeded by Prisma on https://www.prisma.io/docs/guides/database/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices.

Additionally, I've been able to restore turbo caching to the `generate-db` script from `packages/db` and hoist the generated artifacts from the client to the root of the project. This seems to solve the problem found with Next, where it doesn't play well with non-node_module dirs.

To reproduce and test caching behavior for the Prisma Client and applications:
1. Clone the repo and install the dependencies.
2. Run the `build` script on the root of the project. It should both generate the client, and build the `@acme/nextjs` project.
3. Run the `build` script a second time. It should be a full Turbo cache of both the Prisma client and the Next.js application.
4. Modify something on `@acme/nextjs` to invalidate it's cache. Run the `build` script again. The Prisma Client should be pulled from cache, while the application is rebuilt.
5. Modify something on the Prisma schema file. Run the `build` script again. Both the Prisma Client and the application should get rebuilt. 

I can't say for sure how well these settings are going to play with Turbo's Remote caching, and my current environment also doesn't let me experiment with the Expo project very well.