### PR TITLE
Fix `auth` branch errors

### DIFF
--- a/apps/nextjs/next.config.mjs
+++ b/apps/nextjs/next.config.mjs
@@ -14,7 +14,7 @@ function defineNextConfig(config) {
   return config;
 }
 
-export default withTM(["@acme/api", "@acme/db"])(
+export default withTM(["@acme/api", "@acme/auth", "@acme/db"])(
   defineNextConfig({
     reactStrictMode: true,
     swcMinify: true,

--- a/apps/nextjs/src/pages/_app.tsx
+++ b/apps/nextjs/src/pages/_app.tsx
@@ -1,10 +1,20 @@
 // src/pages/_app.tsx
 import "../styles/globals.css";
+import { SessionProvider } from "next-auth/react";
+import type { Session } from "next-auth";
+
 import type { AppType } from "next/app";
 import { trpc } from "../utils/trpc";
 
-const MyApp: AppType = ({ Component, pageProps }) => {
-  return <Component {...pageProps} />;
+const MyApp: AppType<{ session: Session | null }> = ({
+  Component,
+  pageProps: { session, ...pageProps },
+}) => {
+  return (
+    <SessionProvider session={session}>
+      <Component {...pageProps} />
+    </SessionProvider>
+  );
 };
 
 export default trpc.withTRPC(MyApp);

--- a/apps/nextjs/src/pages/index.tsx
+++ b/apps/nextjs/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import type { NextPage } from "next";
 import Head from "next/head";
+import { signIn, signOut, useSession } from "next-auth/react";
 import { trpc } from "../utils/trpc";
 import type { inferProcedureOutput } from "@trpc/server";
 import type { AppRouter } from "@acme/api";
@@ -40,9 +41,40 @@ const Home: NextPage = () => {
             <p>Loading..</p>
           )}
         </div>
+        <AuthShowcase />
       </main>
     </>
   );
 };
 
 export default Home;
+
+const AuthShowcase: React.FC = () => {
+  const { data: secretMessage } = trpc.auth.getSecretMessage.useQuery();
+
+  const { data: sessionData } = useSession();
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-2">
+      {sessionData && (
+        <>
+          <p className="text-2xl text-blue-500">
+            Logged in as {sessionData?.user?.name}
+          </p>
+          <p className="text-sm text-gray-500">
+            User Id: {sessionData?.user?.id}
+          </p>
+        </>
+      )}
+      {secretMessage && (
+        <p className="text-2xl text-blue-500">{secretMessage}</p>
+      )}
+      <button
+        className="rounded-md border border-black bg-violet-50 px-4 py-2 text-xl shadow-lg hover:bg-violet-100"
+        onClick={sessionData ? () => signOut() : () => signIn()}
+      >
+        {sessionData ? "Sign out" : "Sign in"}
+      </button>
+    </div>
+  );
+};

--- a/apps/nextjs/tsconfig.json
+++ b/apps/nextjs/tsconfig.json
@@ -1,4 +1,11 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"]
+  "include": [
+    "next-env.d.ts",
+    "node_modules/@acme/auth/next-auth.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.cjs",
+    "**/*.mjs"
+  ]
 }

--- a/packages/api/src/router/auth.ts
+++ b/packages/api/src/router/auth.ts
@@ -1,0 +1,14 @@
+import { protectedProcedure, publicProcedure, router } from "../trpc";
+
+export const authRouter = router({
+  getSession: publicProcedure.query(({ ctx }) => {
+    return ctx.session;
+  }),
+  getSecretMessage: protectedProcedure.query(({ ctx }) => {
+    // testing type validation of overridden next-auth Session in @acme/auth package
+    return `
+        Hello ${ctx.session.user.id}
+        You are logged in and can see this secret message!
+    `;
+  }),
+});

--- a/packages/api/src/router/index.ts
+++ b/packages/api/src/router/index.ts
@@ -1,8 +1,10 @@
-import { router } from '../trpc';
-import { postRouter } from './post';
+import { router } from "../trpc";
+import { postRouter } from "./post";
+import { authRouter } from "./auth";
 
 export const appRouter = router({
   post: postRouter,
+  auth: authRouter,
 });
 
 // export type definition of API

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,4 +1,9 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src", "index.ts", "transformer.ts"]
+  "include": [
+    "src",
+    "index.ts",
+    "transformer.ts",
+    "node_modules/@acme/auth/next-auth.d.ts"
+  ]
 }


### PR DESCRIPTION
Integrates #36

- Fix `nextjs` compilation error by adding `@acme/auth` to the list of nextjs transpiled modules
- Add typescript validation to next-auth `Session` augmented type in packages other than `@acme/auth`
- Add Auth example in nextjs web app