### PR TITLE
fix: disable lint during build in CI

### DIFF
--- a/apps/nextjs/next.config.mjs
+++ b/apps/nextjs/next.config.mjs
@@ -13,6 +13,10 @@ const config = {
     // Enables hot-reload and easy integration for local packages
     transpilePackages: ["@acme/api", "@acme/auth", "@acme/db"],
   },
+  // We already do linting on GH actions
+  eslint: {
+    ignoreDuringBuilds: !!process.env.CI,
+  },
 };
 
 export default config;


### PR DESCRIPTION
Don't need to double run the linter during CI