### PR TITLE
Export prisma/client from db to expose types to other packages

### DIFF
--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -15,6 +15,8 @@ export const prisma =
         : ["error"],
   });
 
+export * from '@prisma/client';
+
 if (process.env.NODE_ENV !== "production") {
   global.prisma = prisma;
 }


### PR DESCRIPTION
This allows accessing the types generated by prisma in other packages.