### PR TITLE
fix: add -- to pass flags to underlying command

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf .turbo node_modules",
-    "with-env": "dotenv -e ../../.env",
+    "with-env": "dotenv -e ../../.env --",
     "dev": "pnpm with-env prisma studio --port 5556",
     "db-push": "pnpm with-env prisma db push",
     "db-generate": "pnpm with-env prisma generate"


### PR DESCRIPTION
Currently, the `dev` script `pnpm with-env prisma studio --port 5556` does not open prisma studio to port 5556. This is because `dotenv-cli` requires a `--` to distinguish between flags passed to dotenv and flags passed to the underlying command ([see docs](https://github.com/entropitor/dotenv-cli#flags-to-the-underlying-command)).

Adding a `--` to the end of the `with-env` script solves this.

**Alternative solution**:
We could move `--` to the individual scripts using `with-env` rather than within the `with-env` script itself.
Example: `pnpm with-env -- prisma studio --port 5556`