### PR TITLE
Alphabetize expo package.json, add type-check script to expo

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -3,13 +3,14 @@
   "version": "0.1.0",
   "main": "index.ts",
   "scripts": {
-    "start": "expo start",
-    "dev": "expo start --ios",
-    "clean": "rm -rf .expo .turbo node_modules",
     "android": "expo start --android",
+    "clean": "rm -rf .expo .turbo node_modules",
+    "dev": "expo start --ios",
     "ios": "expo start --ios",
-    "web": "expo start --web",
     "lint": "eslint . --ext ts,tsx"
+    "start": "expo start",
+    "type-check": "tsc --noEmit",
+    "web": "expo start --web",
   },
   "dependencies": {
     "@acme/api": "*",

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -7,10 +7,10 @@
     "clean": "rm -rf .expo .turbo node_modules",
     "dev": "expo start --ios",
     "ios": "expo start --ios",
-    "lint": "eslint . --ext ts,tsx"
+    "lint": "eslint . --ext ts,tsx",
     "start": "expo start",
     "type-check": "tsc --noEmit",
-    "web": "expo start --web",
+    "web": "expo start --web"
   },
   "dependencies": {
     "@acme/api": "*",


### PR DESCRIPTION
Noticed `pnpm type-check` wasn't checking against the expo app. I alphabetized the scripts while I was in there.