### PR TITLE
Fix SafeAreaView import to work correctly on Android

### DIFF
--- a/apps/expo/src/screens/home.tsx
+++ b/apps/expo/src/screens/home.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
 import {
-  SafeAreaView,
   Text,
   TextInput,
   TouchableOpacity,
   View,
 } from "react-native";
 
+import { SafeAreaView } from "react-native-safe-area-context";
 import { FlashList } from "@shopify/flash-list";
 import type { inferProcedureOutput } from "@trpc/server";
 import type { AppRouter } from "@acme/api";


### PR DESCRIPTION
SafeAreaView imported from react native is not working on Android. The correct is to import it from react-native-safe-area-context.