### PR TITLE
feat(ci): skip nextjs env validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Build, lint and type-check
         run: pnpm turbo build lint type-check
+        env:
+          SKIP_ENV_VALIDATION: true
 
       - name: Check workspaces
         run: pnpm manypkg check


### PR DESCRIPTION
Use environment variable to skip validations on `CI.yml` workflow, or is there a reason to validate env schema there?