### PR TITLE
fix: check if lines are already appended in the expo plugin

### DIFF
--- a/apps/expo/expo-plugins/with-modify-gradle.js
+++ b/apps/expo/expo-plugins/with-modify-gradle.js
@@ -10,20 +10,31 @@ const { withProjectBuildGradle } = require("@expo/config-plugins");
 
 module.exports = (config) => {
   return withProjectBuildGradle(config, (config) => {
-    config.modResults.contents = config.modResults.contents.replace(
-      "buildscript {",
-      `buildscript {
+    if (!config.modResults.contents.includes("ext.getPackageJsonVersion =")) {
+      config.modResults.contents = config.modResults.contents.replace(
+        "buildscript {",
+        `buildscript {
     ext.getPackageJsonVersion = { packageName ->
         new File(['node', '--print', "JSON.parse(require('fs').readFileSync(require.resolve('\${packageName}/package.json'), 'utf-8')).version"].execute(null, rootDir).text.trim())
     }`,
-    );
+      );
+    }
 
-    config.modResults.contents = config.modResults.contents.replace(
-      "ext {",
-      `ext {
-        reactNativeVersion = "\${ext.getPackageJsonVersion('react-native')}"
+    if (!config.modResults.contents.includes("reactNativeVersion =")) {
+      config.modResults.contents = config.modResults.contents.replace(
+        "ext {",
+        `ext {
+        reactNativeVersion = "\${ext.getPackageJsonVersion('react-native')}"`,
+      );
+    }
+
+    if (!config.modResults.contents.includes("expoPackageVersion =")) {
+      config.modResults.contents = config.modResults.contents.replace(
+        "ext {",
+        `ext {
         expoPackageVersion = "\${ext.getPackageJsonVersion('expo')}"`,
-    );
+      );
+    }
 
     return config;
   });


### PR DESCRIPTION
Forgot to check if the lines were appended while writing the plugin, so here's the fix that will not allow them to be inserted multiple times.