### PR TITLE
Add SKIP_ENV_VALIDATION notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Let's deploy the Next.js application to [Vercel](https://vercel.com/). If you ha
 
 > The install command filters out the expo package and saves a few second (and cache size) of dependency installation. The build command makes us build the application using Turbo.
 
-2. Add your `DATABASE_URL` environment variable.
+2. Add your `DATABASE_URL` environment variable. Ensure `SKIP_ENV_VALIDATION` is set to `true` when deploying to production.
 
 3. Done! Your app should successfully deploy. Assign your domain and use that instead of `localhost` for the `url` in the Expo app so that your Expo app can communicate with your backend when you are not in development.
 

--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -1,8 +1,9 @@
 import { ExpoConfig, ConfigContext } from "@expo/config";
 
 const defineConfig = (_ctx: ConfigContext): ExpoConfig => ({
-  name: "expo",
-  slug: "expo",
+  name: "ElasticTasks",
+  slug: "elastictasks",
+  owner: "albertmzb",
   version: "1.0.0",
   orientation: "portrait",
   icon: "./assets/icon.png",
@@ -18,7 +19,7 @@ const defineConfig = (_ctx: ConfigContext): ExpoConfig => ({
   assetBundlePatterns: ["**/*"],
   ios: {
     supportsTablet: true,
-    bundleIdentifier: "your.bundle.identifier",
+    bundleIdentifier: "io.albertdb.elastictasks",
   },
   android: {
     adaptiveIcon: {
@@ -27,11 +28,12 @@ const defineConfig = (_ctx: ConfigContext): ExpoConfig => ({
     },
   },
   extra: {
+    productionApiUrl: process.env.PRODUCTION_API_URL,
     eas: {
-      projectId: "your-project-id",
+      projectId: "6dc95de8-2e4b-4152-81e1-8b563903f13e",
     },
   },
-  plugins: ["./expo-plugins/with-modify-gradle.js"]
+  plugins: ["./expo-plugins/with-modify-gradle.js"],
 });
 
 export default defineConfig;

--- a/apps/expo/src/utils/api.tsx
+++ b/apps/expo/src/utils/api.tsx
@@ -28,6 +28,16 @@ const getBaseUrl = () => {
    * you'll have to manually set it. NOTE: Port 3000 should work for most but confirm
    * you don't have anything else running on it, or you'd have to change it.
    */
+
+  // Check if we're running in production
+  if (!__DEV__) {
+    const productionApiUrl = Constants.manifest?.extra
+      ?.productionApiUrl as string;
+    if (!productionApiUrl)
+      throw new Error("failed to get productionApiUrl, configure it manually");
+    return productionApiUrl;
+  }
+
   const localhost = Constants.manifest?.debuggerHost?.split(":")[0];
   if (!localhost)
     throw new Error("failed to get localhost, configure it manually");


### PR DESCRIPTION
The SKIP_ENV_VALIDATION was introduced in [1824e40](https://github.com/t3-oss/create-t3-turbo/commit/1824e40241db58f3a85d574816075eaa0a547397).

I updated the README to provide a notice that it must be set to true when deploying to production.
Otherwise, a deployment to Vercel will fail.