### PR TITLE
chore: Add SKIP_ENV_VALIDATION notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Let's deploy the Next.js application to [Vercel](https://vercel.com/). If you ha
 
 > The install command filters out the expo package and saves a few second (and cache size) of dependency installation. The build command makes us build the application using Turbo.
 
-2. Add your `DATABASE_URL` environment variable.
+2. Add your `DATABASE_URL` environment variable. Ensure `SKIP_ENV_VALIDATION` is set to `true` when deploying to production.
 
 3. Done! Your app should successfully deploy. Assign your domain and use that instead of `localhost` for the `url` in the Expo app so that your Expo app can communicate with your backend when you are not in development.
 


### PR DESCRIPTION
The SKIP_ENV_VALIDATION was introduced in [1824e40](https://github.com/t3-oss/create-t3-turbo/commit/1824e40241db58f3a85d574816075eaa0a547397).

I updated the README to provide a notice that it must be set to true when deploying to production.
Otherwise, a deployment to Vercel will fail.