### PR TITLE
Use optional chaining

### DIFF
--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -100,7 +100,7 @@ export const publicProcedure = t.procedure;
  * procedure
  */
 const enforceUserIsAuthed = t.middleware(({ ctx, next }) => {
-  if (!ctx.session || !ctx.session.user) {
+  if (!ctx.session?.user) {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
   return next({


### PR DESCRIPTION
Rather than checking that `session` exists AND `session.user` exists. Simply check that `session?.user` exists.