### PR TITLE
expo-cli 3.3.0

### DIFF
--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -1,5 +1,5 @@
 {
-  "cli": { "version": ">= 3.1.1" },
+  "cli": { "version": ">= 3.3.0" },
   "build": {
     "development": {
       "developmentClient": true,


### PR DESCRIPTION
Fixes `InvalidEasJsonError: eas.json is not valid.` error when running `eas build` with an eas-cli version < 3.3.0.

`build.preview.ios.resourceClass` is only supported in eas-cli >= 3.3.0

![Bildschirmfoto 2023-01-31 um 02 59 05](https://user-images.githubusercontent.com/30775450/215641665-b837a0da-4aef-4841-a58a-40adae31c783.jpg)
