### PR TITLE
docs: update `api` util and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ pnpm db:push
 
 _We do not recommend deploying a SQLite database on serverless environments since the data wouldn't be persisted. I provisioned a quick Postgresql database on [Railway](https://railway.app), but you can of course use any other database provider. Make sure the prisma schema is updated to use the correct database._
 
+**Please note that the Next.js application with tRPC must be deployed in order for the Expo app to communicate with the server in a production environment.**
+
 #### Deploy to Vercel
 
 Let's deploy the Next.js application to [Vercel](https://vercel.com/). If you have ever deployed a Turborepo app there, the steps are quite straightforward. You can also read the [official Turborepo guide](https://vercel.com/docs/concepts/monorepos/turborepo) on deploying to Vercel.

--- a/apps/expo/src/utils/api.tsx
+++ b/apps/expo/src/utils/api.tsx
@@ -35,8 +35,10 @@ const getBaseUrl = () => {
    * you don't have anything else running on it, or you'd have to change it.
    */
   const localhost = Constants.manifest?.debuggerHost?.split(":")[0];
-  if (!localhost)
-    throw new Error("failed to get localhost, configure it manually");
+  if (!localhost) {
+    // return "https://your-production-url.com";
+    throw new Error("Failed to get localhost. Please point to your production server.");
+  }
   return `http://${localhost}:3000`;
 };
 


### PR DESCRIPTION
**Why?**

I recently tested out how easy it would be to go from a bootstrapped template to a deployed application in Testflight. I discovered that the Expo app needs a deployed server in order to communicate with the tRPC backend logic (of course 🤦🏼‍♂️).

I felt that this was not clearly stated in the documentation, so here are my two cents. I'm of course open to any proposed changes ☺️