### PR TITLE
Configure EAS Builds to Use M1 Workers

### DIFF
--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -1,15 +1,29 @@
 {
-  "cli": { "version": ">= 3.3.0" },
+  "cli": {
+    "version": ">= 3.3.0"
+  },
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "ios": {
+        "resourceClass": "m1-medium"
+      }
     },
     "preview": {
-      "ios": { "simulator": true, "resourceClass": "m1-medium" },
-      "distribution": "internal"
+      "distribution": "internal",
+      "ios": {
+        "simulator": true,
+        "resourceClass": "m1-medium"
+      }
     },
-    "production": {}
+    "production": {
+      "ios": {
+        "resourceClass": "m1-medium"
+      }
+    }
   },
-  "submit": { "production": {} }
+  "submit": {
+    "production": {}
+  }
 }


### PR DESCRIPTION
- I configured both `development` and `production` builds to make use of M1 workers; they were previously only configured for `preview` builds. [Expo says](https://blog.expo.dev/m1-workers-on-eas-build-dcaa2c1333ad) that M1 workers generally speed up builds, and will be the default before Q2 2023.
- I indented the `eas.json` file and arranged the json properties alphabetically for better readability.