### PR TITLE
fix: re-enable manypkg in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,5 @@ jobs:
         env:
           SKIP_ENV_VALIDATION: true
 
-      # FIXME: Add this back once we have an Expo SDK supporting React 18.2
-      # - name: Check workspaces
-      #   run: pnpm manypkg check
+      - name: Check workspaces
+        run: pnpm manypkg check

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "prettier": "^2.8.3",
-    "prettier-plugin-tailwindcss": "^0.2.2",
     "prettier-plugin-organize-imports": "^3.2.2",
+    "prettier-plugin-tailwindcss": "^0.2.2",
     "turbo": "^1.7.4",
     "typescript": "^4.9.5"
   },


### PR DESCRIPTION
Now that Expo SDK was upgraded to v48 it supports React 18.2, meaning the `manypkg check` can be re-enabled in CI.
In addition, running `manypkg check` resulted in an error so `manypkg fix` sorted the relevant imports.