### PR TITLE
fix(renovate): don't run renovate on acme

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["^@acme/"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
This should stop the "Renovate failed to look up the following dependencies" warnings for acme packages