### PR TITLE
fix: make clean scripts compatible with windows

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "main": "index.ts",
   "scripts": {
-    "clean": "rm -rf .expo .turbo node_modules",
+    "clean": "git clean -xdf .expo .turbo node_modules",
     "dev": "expo start --ios",
     "dev:android": "expo start --android",
     "dev:ios": "expo start --ios",

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "pnpm with-env next build",
-    "clean": "rm -rf .next .turbo node_modules",
+    "clean": "git clean -xdf .next .turbo node_modules",
     "dev": "pnpm with-env next dev",
     "lint": "SKIP_ENV_VALIDATION=1 next lint",
     "lint:fix": "pnpm lint --fix",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@7.28.0",
   "scripts": {
     "build": "pnpm with-env turbo build",
-    "clean": "rm -rf node_modules",
+    "clean": "git clean -xdf node_modules",
     "clean:workspaces": "turbo clean",
     "db:generate": "pnpm with-env turbo db:generate",
     "db:push": "pnpm with-env turbo db:push db:generate",


### PR DESCRIPTION
I just noticed that the clean scripts are using `rm -rf`, which doesn't work on Windows machines. I know, it's probably not the best dev OS, but lots of people are using Windows :)

There are other ways to achieve this, but I found that this is one of the cleanest ways. It does assume that people use git, but even windows users _should_ be using git.