### PR TITLE
docs: Add manual expo start instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ pnpm db:push
 #### Use iOS Simulator
 
 1. Make sure you have XCode and XCommand Line Tools installed [as shown on expo docs](https://docs.expo.dev/workflow/ios-simulator/).
-   > **NOTE:** If you just installed XCode, or if you have updated it, you need to open the simulator manually once before you can run it using the turbo `dev`-script.
+   > **NOTE:** If you just installed XCode, or if you have updated it, you need to open the simulator manually once. Run `npx expo start` in the root dir, and then enter `I` to launch Expo Go. After the manual launch, you can run `pnpm dev` in the root directory.
 
 ```diff
 +  "dev": "expo start --ios",


### PR DESCRIPTION
Current instructions aren't the most specific. See https://github.com/t3-oss/create-t3-turbo/issues/94.