### PR TITLE
Use workspace prefix for workspace dependencies

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -32,8 +32,8 @@
     "superjson": "1.9.1"
   },
   "devDependencies": {
-    "@acme/api": "*",
-    "@acme/tailwind-config": "*",
+    "@acme/api": "workspace:*",
+    "@acme/tailwind-config": "workspace:*",
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -12,10 +12,10 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@acme/api": "*",
-    "@acme/auth": "*",
-    "@acme/db": "*",
-    "@acme/tailwind-config": "*",
+    "@acme/api": "workspace:*",
+    "@acme/auth": "workspace:*",
+    "@acme/db": "workspace:*",
+    "@acme/tailwind-config": "workspace:*",
     "@tanstack/react-query": "^4.24.10",
     "@trpc/client": "^10.14.0",
     "@trpc/next": "^10.14.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,8 +11,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@acme/auth": "*",
-    "@acme/db": "*",
+    "@acme/auth": "workspace:*",
+    "@acme/db": "workspace:*",
     "@trpc/client": "^10.14.0",
     "@trpc/server": "^10.14.0",
     "superjson": "1.9.1",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -11,7 +11,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@acme/db": "*",
+    "@acme/db": "workspace:*",
     "@next-auth/prisma-adapter": "^1.0.5",
     "next": "^13.2.3",
     "next-auth": "^4.20.1",


### PR DESCRIPTION
Use the workspace prefix in package.json, for workspace dependencies, to prevent installation of unwanted packages.