### PR TITLE
update renovate to keep deps more up to date

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,6 @@
       "enabled": false
     }
   ],
-  "updateInternalDeps": true
+  "updateInternalDeps": true,
+  "rangeStrategy": "bump"
 }


### PR DESCRIPTION
See the discussion on #214 

This will keep tell Renovate to keep NPM dependencies more up to date.  As well as updating the `package.json` ranges in the process.