### PR TITLE
Update package.json

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "clean": "git clean -xdf .next .turbo node_modules",
     "dev": "next dev",
-    "lint": "SKIP_ENV_VALIDATION=1 next lint",
+    "lint": "SET SKIP_ENV_VALIDATION=1 next lint",
     "lint:fix": "pnpm lint --fix",
     "start": "next start",
     "type-check": "tsc --noEmit"


### PR DESCRIPTION
When you run pnpm lint, 'SKIP_ENV_VALIDATION' will throw a 'not recognized command' error, adding SET on the script of lint inside nextjs app package.json solves it.
![Screenshot_2](https://user-images.githubusercontent.com/81532541/227807427-46cc4890-fe3b-4402-8faa-c2dbf0dc56a3.png)
![Screenshot_3](https://user-images.githubusercontent.com/81532541/227807432-caa4c5db-409a-489a-8d9e-1e8baae54e6d.png)
