### PR TITLE
Prevent pnpm from adding the workspace: prefix while preferring local packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -10,3 +10,9 @@ public-hoist-pattern[]=*prisma*
 # but we don't want it installed there since it's already
 # installed in the @acme/db package
 strict-peer-dependencies=false
+
+# Prevent pnpm from adding the "workspace:"" prefix to local
+# packages as it casues issues with manypkg
+# @link https://pnpm.io/npmrc#prefer-workspace-packages
+save-workspace-protocol=false
+prefer-workspace-packages=true

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -32,9 +32,9 @@
     "superjson": "1.9.1"
   },
   "devDependencies": {
-    "@acme/api": "*",
-    "@acme/eslint-config": "*",
-    "@acme/tailwind-config": "*",
+    "@acme/api": "^0.1.0",
+    "@acme/eslint-config": "^0.1.0",
+    "@acme/tailwind-config": "^0.1.0",
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -12,10 +12,10 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@acme/api": "*",
-    "@acme/auth": "*",
-    "@acme/db": "*",
-    "@acme/tailwind-config": "*",
+    "@acme/api": "^0.1.0",
+    "@acme/auth": "^0.1.0",
+    "@acme/db": "^0.1.0",
+    "@acme/tailwind-config": "^0.1.0",
     "@tanstack/react-query": "^4.28.0",
     "@trpc/client": "^10.18.0",
     "@trpc/next": "^10.18.0",
@@ -29,7 +29,7 @@
     "zod": "^3.21.4"
   },
   "devDependencies": {
-    "@acme/eslint-config": "*",
+    "@acme/eslint-config": "^0.1.0",
     "@types/node": "^18.15.10",
     "@types/react": "^18.0.29",
     "@types/react-dom": "^18.0.11",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,15 +11,15 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@acme/auth": "*",
-    "@acme/db": "*",
+    "@acme/auth": "^0.1.0",
+    "@acme/db": "^0.1.0",
     "@trpc/client": "^10.18.0",
     "@trpc/server": "^10.18.0",
     "superjson": "1.9.1",
     "zod": "^3.21.4"
   },
   "devDependencies": {
-    "@acme/eslint-config": "*",
+    "@acme/eslint-config": "^0.1.0",
     "eslint": "^8.36.0",
     "typescript": "^5.0.2"
   }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -11,7 +11,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@acme/db": "*",
+    "@acme/db": "^0.1.0",
     "@next-auth/prisma-adapter": "^1.0.5",
     "next": "^13.2.4",
     "next-auth": "^4.20.1",
@@ -19,7 +19,7 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@acme/eslint-config": "*",
+    "@acme/eslint-config": "^0.1.0",
     "eslint": "^8.36.0",
     "typescript": "^5.0.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,9 +28,9 @@ importers:
 
   apps/expo:
     specifiers:
-      '@acme/api': '*'
-      '@acme/eslint-config': '*'
-      '@acme/tailwind-config': '*'
+      '@acme/api': ^0.1.0
+      '@acme/eslint-config': ^0.1.0
+      '@acme/tailwind-config': ^0.1.0
       '@babel/core': ^7.20.0
       '@babel/preset-env': ^7.20.0
       '@babel/runtime': ^7.20.0
@@ -95,11 +95,11 @@ importers:
 
   apps/nextjs:
     specifiers:
-      '@acme/api': '*'
-      '@acme/auth': '*'
-      '@acme/db': '*'
-      '@acme/eslint-config': '*'
-      '@acme/tailwind-config': '*'
+      '@acme/api': ^0.1.0
+      '@acme/auth': ^0.1.0
+      '@acme/db': ^0.1.0
+      '@acme/eslint-config': ^0.1.0
+      '@acme/tailwind-config': ^0.1.0
       '@tanstack/react-query': ^4.28.0
       '@trpc/client': ^10.18.0
       '@trpc/next': ^10.18.0
@@ -148,9 +148,9 @@ importers:
 
   packages/api:
     specifiers:
-      '@acme/auth': '*'
-      '@acme/db': '*'
-      '@acme/eslint-config': '*'
+      '@acme/auth': ^0.1.0
+      '@acme/db': ^0.1.0
+      '@acme/eslint-config': ^0.1.0
       '@trpc/client': ^10.18.0
       '@trpc/server': ^10.18.0
       eslint: ^8.36.0
@@ -171,8 +171,8 @@ importers:
 
   packages/auth:
     specifiers:
-      '@acme/db': '*'
-      '@acme/eslint-config': '*'
+      '@acme/db': ^0.1.0
+      '@acme/eslint-config': ^0.1.0
       '@next-auth/prisma-adapter': ^1.0.5
       eslint: ^8.36.0
       next: ^13.2.4


### PR DESCRIPTION
After previous conversation on #216 , I have made the necessary changes to prevent pnpm from trying to add the "workspace:" prefix on local packages, while still preferring local packages. I have also modified the local package versions on all package.json files to be consistent with each other.