### PR TITLE
fix: update gitignore, database not being ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@ node_modules
 coverage
 
 # database
-prisma/db.sqlite
-prisma/db.sqlite-journal
+**/prisma/db.sqlite
+**/prisma/db.sqlite-journal
 
 # next.js
 .next/


### PR DESCRIPTION
Updating the path of prisma db in `.gitignore` so it's more generic and properly ignores the databases