### PR TITLE
feat: add prisma studio command

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clean:workspaces": "turbo clean",
     "db:generate": "turbo db:generate",
     "db:push": "turbo db:push db:generate",
+    "db:studio": "turbo db:studio",
     "dev": "turbo dev --parallel",
     "format": "prettier --write \"**/*.{js,cjs,mjs,ts,tsx,md,json}\" --ignore-path .gitignore",
     "lint": "turbo lint && manypkg check",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -8,6 +8,7 @@
     "clean": "rm -rf .turbo node_modules",
     "db:generate": "pnpm with-env prisma generate",
     "db:push": "pnpm with-env prisma db push --skip-generate",
+    "db:studio": "pnpm with-env prisma studio --port 5556",
     "dev": "pnpm with-env prisma studio --port 5556",
     "with-env": "dotenv -e ../../.env --"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,10 @@
       "inputs": ["prisma/schema.prisma"],
       "cache": false
     },
+    "db:studio": {
+      "inputs": ["prisma/schema.prisma"],
+      "cache": false
+    },
     "dev": {
       "persistent": true,
       "cache": false


### PR DESCRIPTION
It would be great if there was a convenient way to run prisma studio with `pnpm db:studio` similar to the `pnpm db:push` command.