### PR TITLE
fix: bring back `type-check` script

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -9,7 +9,7 @@
     "dev:ios": "expo start --ios",
     "lint": "eslint .",
     "lint:fix": "pnpm lint --fix",
-    "FIXME(no-work):type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@expo/metro-config": "^0.7.1",


### PR DESCRIPTION
Brings back the `type-check` script as the expo router issue got fixed (see https://github.com/t3-oss/create-t3-turbo/issues/185#issuecomment-1493038578)