### PR TITLE
update eas-expo build resource class

### DIFF
--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -7,19 +7,19 @@
       "developmentClient": true,
       "distribution": "internal",
       "ios": {
-        "resourceClass": "m1-medium"
+        "resourceClass": "m-medium"
       }
     },
     "preview": {
       "distribution": "internal",
       "ios": {
         "simulator": true,
-        "resourceClass": "m1-medium"
+        "resourceClass": "m-medium"
       }
     },
     "production": {
       "ios": {
-        "resourceClass": "m1-medium"
+        "resourceClass": "m-medium"
       }
     }
   },


### PR DESCRIPTION
`m1-medium` has been deprecated. `m-medium` is now the preference.  See https://docs.expo.dev/build-reference/eas-json/#ios-specific-options

I found this creating a build.  `eas` show this warning:

```bash
$ eas build --profile preview --platform ios
Resource class m1-medium is deprecated. Use m-medium instead.
```