### PR TITLE
fix: pnpm clean not working as expected

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@8.1.1",
   "scripts": {
     "build": "turbo build",
-    "clean": "git clean -xdf node_modules",
+    "clean": "git clean -xdf --exclude=.env",
     "clean:workspaces": "turbo clean",
     "db:generate": "turbo db:generate",
     "db:push": "turbo db:push db:generate",


### PR DESCRIPTION
 
 ## Is this expected?
 The script for `pnpm clean` is the first that I executed in the screenshot: `git clean -xdf node_modules`
 - Why are we not deleting the nested `node_modules`?
 - Why are we not deleting the expo and nextjs cache?

I interpreted that as a mistake and I opened this PR to fix it.
 
![image](https://user-images.githubusercontent.com/10969700/232180011-8f2a3e0c-de6e-45cd-aba3-04baa9e55a84.png)

## This PR
Changes `pnpm clean`
|from|to|
|---|---|
|`git clean -xdf node_modules`|`git clean -xdf --exclude=.env`|
|Deletes only the root node_modules directory|Deletes everything not tracked by git, including cache and all node_modules. The only exception is the `.env` file|

I figured deleting `.env` all the time was not convenient at all, so that's why I decided to exclude it. 
