### PR TITLE
fix localhost determination during expo local dev

### DIFF
--- a/apps/expo/src/utils/api.tsx
+++ b/apps/expo/src/utils/api.tsx
@@ -26,7 +26,10 @@ const getBaseUrl = () => {
    * **NOTE**: This is only for development. In production, you'll want to set the
    * baseUrl to your production API URL.
    */
-  const localhost = Constants.manifest?.debuggerHost?.split(":")[0];
+  const debuggerHost =
+    Constants.manifest?.debuggerHost ??
+    Constants.manifest2?.extra?.expoGo?.debuggerHost;
+  const localhost = debuggerHost?.split(":")[0];
   if (!localhost) {
     // return "https://your-production-url.com";
     throw new Error(


### PR DESCRIPTION
Turns out when just using expo go and local development what was originally here works fine.  But if you end up building your own dev client (https://docs.expo.dev/develop/development-builds/introduction/#what-is-an-expo-dev-client) then `manifest` will no longer be around. Instead you need to use `manifest2`.

See description of `manifest` and `manifest2` here: https://docs.expo.dev/versions/latest/sdk/constants/#nativeconstants

![image](https://user-images.githubusercontent.com/18610918/233408505-7ceeec49-bf69-4c99-9df2-d39305e51dda.png)

