### PR TITLE
Simplify `as unknown as ...` cast in db/index.ts

### DIFF
--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -2,7 +2,7 @@ import { PrismaClient } from "@prisma/client";
 
 export * from "@prisma/client";
 
-const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
+const globalForPrisma = globalThis as { prisma?: PrismaClient };
 
 export const prisma =
   globalForPrisma.prisma ||


### PR DESCRIPTION
Switch to a slightly more "honest" cast of `globalThis` in the db index file.

`globalThis` _is_ an object which has an optional `prisma` property - it doesn't make much difference in this case but casting to `as unknown` allows making a slightly more unsafe cast, which isn't needed here - at least I don't think it is.