### PR TITLE
Make an @acme/env package usable in the other monorepo packages

### DIFF
--- a/apps/nextjs/next.config.mjs
+++ b/apps/nextjs/next.config.mjs
@@ -2,7 +2,7 @@
  * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation.
  * This is especially useful for Docker builds and Linting.
  */
-// !process.env.SKIP_ENV_VALIDATION && (await import("./src/env.mjs"));
+await import("@acme/env");
 
 /** @type {import("next").NextConfig} */
 const config = {

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -16,6 +16,7 @@
     "@acme/api": "^0.1.0",
     "@acme/auth": "^0.1.0",
     "@acme/db": "^0.1.0",
+    "@acme/env": "^0.1.0",
     "@acme/tailwind-config": "^0.1.0",
     "@t3-oss/env-nextjs": "^0.2.1",
     "@tanstack/react-query": "^4.29.5",

--- a/apps/nextjs/src/utils/api.ts
+++ b/apps/nextjs/src/utils/api.ts
@@ -3,10 +3,11 @@ import { createTRPCNext } from "@trpc/next";
 import superjson from "superjson";
 
 import type { AppRouter } from "@acme/api";
+import { env } from "@acme/env";
 
 const getBaseUrl = () => {
   if (typeof window !== "undefined") return ""; // browser should use relative url
-  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`; // SSR should use vercel url
+  if (env.VERCEL_URL) return `https://${env.VERCEL_URL}`; // SSR should use vercel url
 
   return `http://localhost:3000`; // dev SSR should use localhost
 };
@@ -18,7 +19,7 @@ export const api = createTRPCNext<AppRouter>({
       links: [
         loggerLink({
           enabled: (opts) =>
-            process.env.NODE_ENV === "development" ||
+            env.NEXT_PUBLIC_ENV === "development" ||
             (opts.direction === "down" && opts.result instanceof Error),
         }),
         httpBatchLink({

--- a/packages/auth/src/auth-options.ts
+++ b/packages/auth/src/auth-options.ts
@@ -3,6 +3,7 @@ import { type DefaultSession, type NextAuthOptions } from "next-auth";
 import DiscordProvider from "next-auth/providers/discord";
 
 import { prisma } from "@acme/db";
+import { env } from "@acme/env";
 
 /**
  * Module augmentation for `next-auth` types
@@ -43,8 +44,8 @@ export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
   providers: [
     DiscordProvider({
-      clientId: process.env.DISCORD_CLIENT_ID as string,
-      clientSecret: process.env.DISCORD_CLIENT_SECRET as string,
+      clientId: env.DISCORD_CLIENT_ID,
+      clientSecret: env.DISCORD_CLIENT_SECRET,
     }),
     /**
      * ...add more providers here

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -1,5 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 
+import { env } from "@acme/env";
+
 export * from "@prisma/client";
 
 const globalForPrisma = globalThis as { prisma?: PrismaClient };
@@ -8,9 +10,7 @@ export const prisma =
   globalForPrisma.prisma ||
   new PrismaClient({
     log:
-      process.env.NODE_ENV === "development"
-        ? ["query", "error", "warn"]
-        : ["error"],
+      env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
   });
 
-if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+if (env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,6 +12,7 @@
     "with-env": "dotenv -e ../../.env --"
   },
   "dependencies": {
+    "@acme/env": "^0.1.0",
     "@prisma/client": "^4.13.0"
   },
   "devDependencies": {

--- a/packages/env/index.mjs
+++ b/packages/env/index.mjs
@@ -1,6 +1,8 @@
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
+const ValidEnv = z.enum(["development", "test", "production"]);
+
 export const env = createEnv({
   /**
    * Specify your server-side environment variables schema here. This way you can ensure the app isn't
@@ -8,7 +10,11 @@ export const env = createEnv({
    */
   server: {
     DATABASE_URL: z.string().url(),
-    NODE_ENV: z.enum(["development", "test", "production"]),
+    NODE_ENV: ValidEnv,
+    VERCEL_URL: process.env.VERCEL
+      ? // VERCEL_URL doesn't include `https` so it cant be validated as a URL
+        z.string()
+      : z.string().optional(),
     NEXTAUTH_SECRET:
       process.env.NODE_ENV === "production"
         ? z.string().min(1)
@@ -29,6 +35,7 @@ export const env = createEnv({
    * For them to be exposed to the client, prefix them with `NEXT_PUBLIC_`.
    */
   client: {
+    NEXT_PUBLIC_ENV: ValidEnv,
     // NEXT_PUBLIC_CLIENTVAR: z.string(),
   },
   /**
@@ -37,10 +44,12 @@ export const env = createEnv({
   runtimeEnv: {
     DATABASE_URL: process.env.DATABASE_URL,
     NODE_ENV: process.env.NODE_ENV,
+    VERCEL_URL: process.env.VERCEL_URL,
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
     DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
     DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
+    NEXT_PUBLIC_ENV: process.env.NODE_ENV,
     // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
   },
 });

--- a/packages/env/index.ts
+++ b/packages/env/index.ts
@@ -1,0 +1,1 @@
+index.mjs

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@acme/auth",
+  "name": "@acme/env",
   "version": "0.1.0",
-  "main": "./index.ts",
+  "main": "./index.mjs",
   "types": "./index.ts",
   "license": "MIT",
   "scripts": {
@@ -11,13 +11,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@acme/db": "^0.1.0",
-    "@acme/env": "^0.1.0",
-    "@next-auth/prisma-adapter": "^1.0.6",
-    "next": "^13.3.1",
-    "next-auth": "^4.22.1",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "@t3-oss/env-nextjs": "^0.2.1",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@acme/eslint-config": "^0.1.0",

--- a/packages/env/tsconfig.json
+++ b/packages/env/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["index.ts", "index.mjs"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       '@acme/db':
         specifier: ^0.1.0
         version: link:../../packages/db
+      '@acme/env':
+        specifier: ^0.1.0
+        version: link:../../packages/env
       '@acme/tailwind-config':
         specifier: ^0.1.0
         version: link:../../packages/config/tailwind
@@ -256,6 +259,9 @@ importers:
       '@acme/db':
         specifier: ^0.1.0
         version: link:../db
+      '@acme/env':
+        specifier: ^0.1.0
+        version: link:../env
       '@next-auth/prisma-adapter':
         specifier: ^1.0.6
         version: 1.0.6(@prisma/client@4.13.0)(next-auth@4.22.1)
@@ -327,6 +333,9 @@ importers:
 
   packages/db:
     dependencies:
+      '@acme/env':
+        specifier: ^0.1.0
+        version: link:../env
       '@prisma/client':
         specifier: ^4.13.0
         version: 4.13.0(prisma@4.13.0)
@@ -337,6 +346,25 @@ importers:
       prisma:
         specifier: ^4.13.0
         version: 4.13.0
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
+
+  packages/env:
+    dependencies:
+      '@t3-oss/env-nextjs':
+        specifier: ^0.2.1
+        version: 0.2.1(zod@3.21.4)
+      zod:
+        specifier: ^3.21.4
+        version: 3.21.4
+    devDependencies:
+      '@acme/eslint-config':
+        specifier: ^0.1.0
+        version: link:../config/eslint
+      eslint:
+        specifier: ^8.38.0
+        version: 8.38.0
       typescript:
         specifier: ^5.0.4
         version: 5.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
   - packages/auth
   - packages/db
   - packages/config/*
+  - packages/env


### PR DESCRIPTION
After @juliusmarminge just pushed the transition to https://env.t3.gg/ I saw an opportunity.  This PR creates a simple @acme/env package that can be installed in the other monorepo packages so you can more systematically and typesafely access environment variables.

The hack that makes this work is that the package's main export is `index.mjs` however `index.ts` sym-links to it in order to provide good typing but still be usable inside of `next.config.mjs`.

I already did this in my own project and it works great.  Thanks for the inspiration @juliusmarminge and the work you did on t3-env!  I did see you were [playing around](https://github.com/t3-oss/create-t3-turbo/pull/135) with something for ENVs a few months ago.  But this seemed so simple in comparison and hopefully an easy win.