### PR TITLE
Skip env validation on lint

### DIFF
--- a/apps/nextjs/src/env.mjs
+++ b/apps/nextjs/src/env.mjs
@@ -23,5 +23,5 @@ export const env = createEnv({
     DATABASE_URL: process.env.DATABASE_URL,
     // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
   },
-  skipValidation: !!process.env.CI,
+  skipValidation: !!process.env.CI || !!process.env.SKIP_ENV_VALIDATION,
 });

--- a/packages/auth/env.mjs
+++ b/packages/auth/env.mjs
@@ -24,5 +24,5 @@ export const env = createEnv({
     DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
     DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
   },
-  skipValidation: !!process.env.CI,
+  skipValidation: !!process.env.CI || !!process.env.SKIP_ENV_VALIDATION,
 });


### PR DESCRIPTION

## How to reproduce

clone a new project a follow the installation guide.
Run pnpm run lint

## Error
Lint fails

<img width="954" alt="image" src="https://github.com/t3-oss/create-t3-turbo/assets/1438153/3599185f-7d21-4182-a9e2-46c5e151eb53">


## Issue

lint fails on .env validation.
On `apps/nextjs/package.json` SKIP_ENV_VALIDATION is set but it is not checked in `createEnv`

This PR ads `SKIP_ENV_VALIDATION` to the `skipValidation` property on `createEnv`