### PR TITLE
add TypeScript config to Turborepo's global dependencies

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turborepo.org/schema.json",
-  "globalDependencies": ["**/.env"],
+  "globalDependencies": ["**/.env", "tsconfig.json"],
   "pipeline": {
     "db:generate": {
       "inputs": ["prisma/schema.prisma"],


### PR DESCRIPTION
A change to `tsconfig.json` should invalidate the cache of all child workspaces, it is the example Turbo [uses in its documentation of `globalDependencies`](https://turbo.build/repo/docs/core-concepts/caching/file-inputs#specifying-additional-inputs).

For example, adding a new type could create different results for the `type-check` job, updating `paths` could alter imports used by various jobs.