### PR TITLE
chore: remove old file from tsconfig's include

### DIFF
--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src", "index.ts", "transformer.ts"]
+  "include": ["src", "index.ts"]
 }


### PR DESCRIPTION
It seems that this got left around after the transformer.ts file got deleted.