### PR TITLE
chore: Replace React.FC with basic function syntax

### DIFF
--- a/apps/expo/src/app/index.tsx
+++ b/apps/expo/src/app/index.tsx
@@ -6,30 +6,30 @@ import { FlashList } from "@shopify/flash-list";
 
 import { api, type RouterOutputs } from "~/utils/api";
 
-const PostCard: React.FC<{
+function PostCard(props: {
   post: RouterOutputs["post"]["all"][number];
   onDelete: () => void;
-}> = ({ post, onDelete }) => {
+}) {
   const router = useRouter();
 
   return (
     <View className="flex flex-row rounded-lg bg-white/10 p-4">
       <View className="flex-grow">
-        <TouchableOpacity onPress={() => router.push(`/post/${post.id}`)}>
+        <TouchableOpacity onPress={() => router.push(`/post/${props.post.id}`)}>
           <Text className="text-xl font-semibold text-pink-400">
-            {post.title}
+            {props.post.title}
           </Text>
-          <Text className="mt-2 text-white">{post.content}</Text>
+          <Text className="mt-2 text-white">{props.post.content}</Text>
         </TouchableOpacity>
       </View>
-      <TouchableOpacity onPress={onDelete}>
+      <TouchableOpacity onPress={props.onDelete}>
         <Text className="font-bold uppercase text-pink-400">Delete</Text>
       </TouchableOpacity>
     </View>
   );
-};
+}
 
-const CreatePost: React.FC = () => {
+function CreatePost() {
   const utils = api.useContext();
 
   const [title, setTitle] = React.useState("");
@@ -82,7 +82,7 @@ const CreatePost: React.FC = () => {
       </TouchableOpacity>
     </View>
   );
-};
+}
 
 const Index = () => {
   const utils = api.useContext();
@@ -118,7 +118,9 @@ const Index = () => {
           data={postQuery.data}
           estimatedItemSize={20}
           ItemSeparatorComponent={() => <View className="h-2" />}
-          renderItem={(p) => (
+          renderItem={(p: {
+            item: { id: string; content: string; title: string };
+          }) => (
             <PostCard
               post={p.item}
               onDelete={() => deletePostMutation.mutate(p.item.id)}

--- a/apps/expo/src/app/index.tsx
+++ b/apps/expo/src/app/index.tsx
@@ -118,9 +118,7 @@ const Index = () => {
           data={postQuery.data}
           estimatedItemSize={20}
           ItemSeparatorComponent={() => <View className="h-2" />}
-          renderItem={(p: {
-            item: { id: string; content: string; title: string };
-          }) => (
+          renderItem={(p) => (
             <PostCard
               post={p.item}
               onDelete={() => deletePostMutation.mutate(p.item.id)}

--- a/apps/expo/src/app/post/[id].tsx
+++ b/apps/expo/src/app/post/[id].tsx
@@ -3,7 +3,7 @@ import { SplashScreen, Stack, useSearchParams } from "expo-router";
 
 import { api } from "~/utils/api";
 
-const Post: React.FC = () => {
+function Post() {
   const { id } = useSearchParams();
   if (!id || typeof id !== "string") throw new Error("unreachable");
   const { data } = api.post.byId.useQuery({ id });
@@ -19,6 +19,6 @@ const Post: React.FC = () => {
       </View>
     </SafeAreaView>
   );
-};
+}
 
 export default Post;

--- a/apps/expo/src/utils/api.tsx
+++ b/apps/expo/src/utils/api.tsx
@@ -43,9 +43,8 @@ const getBaseUrl = () => {
  * A wrapper for your app that provides the TRPC context.
  * Use only in _app.tsx
  */
-export const TRPCProvider: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}) => {
+
+export function TRPCProvider(props: { children: React.ReactNode }) {
   const [queryClient] = React.useState(() => new QueryClient());
   const [trpcClient] = React.useState(() =>
     api.createClient({
@@ -60,7 +59,9 @@ export const TRPCProvider: React.FC<{ children: React.ReactNode }> = ({
 
   return (
     <api.Provider client={trpcClient} queryClient={queryClient}>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
     </api.Provider>
   );
-};
+}

--- a/apps/nextjs/src/pages/index.tsx
+++ b/apps/nextjs/src/pages/index.tsx
@@ -110,17 +110,15 @@ const Home: NextPage = () => {
               ) : (
                 <div className="flex h-[40vh] justify-center overflow-y-scroll px-4 text-2xl">
                   <div className="flex w-full flex-col gap-4">
-                    {postQuery.data?.map(
-                      (p: { id: string; title: string; content: string }) => {
-                        return (
-                          <PostCard
-                            key={p.id}
-                            post={p}
-                            onPostDelete={() => deletePostMutation.mutate(p.id)}
-                          />
-                        );
-                      },
-                    )}
+                    {postQuery.data?.map((p) => {
+                      return (
+                        <PostCard
+                          key={p.id}
+                          post={p}
+                          onPostDelete={() => deletePostMutation.mutate(p.id)}
+                        />
+                      );
+                    })}
                   </div>
                 </div>
               )}

--- a/apps/nextjs/src/pages/index.tsx
+++ b/apps/nextjs/src/pages/index.tsx
@@ -5,29 +5,29 @@ import { signIn, signOut } from "next-auth/react";
 
 import { api, type RouterOutputs } from "~/utils/api";
 
-const PostCard: React.FC<{
+function PostCard(props: {
   post: RouterOutputs["post"]["all"][number];
-  onPostDelete?: () => void;
-}> = ({ post, onPostDelete }) => {
+  onPostDelete: () => void;
+}) {
   return (
     <div className="flex flex-row rounded-lg bg-white/10 p-4 transition-all hover:scale-[101%]">
       <div className="flex-grow">
-        <h2 className="text-2xl font-bold text-pink-400">{post.title}</h2>
-        <p className="mt-2 text-sm">{post.content}</p>
+        <h2 className="text-2xl font-bold text-pink-400">{props.post.title}</h2>
+        <p className="mt-2 text-sm">{props.post.content}</p>
       </div>
       <div>
         <span
           className="cursor-pointer text-sm font-bold uppercase text-pink-400"
-          onClick={onPostDelete}
+          onClick={props.onPostDelete}
         >
           Delete
         </span>
       </div>
     </div>
   );
-};
+}
 
-const CreatePostForm: React.FC = () => {
+function CreatePostForm() {
   const utils = api.useContext();
 
   const [title, setTitle] = useState("");
@@ -78,7 +78,7 @@ const CreatePostForm: React.FC = () => {
       </button>
     </div>
   );
-};
+}
 
 const Home: NextPage = () => {
   const postQuery = api.post.all.useQuery();
@@ -110,15 +110,17 @@ const Home: NextPage = () => {
               ) : (
                 <div className="flex h-[40vh] justify-center overflow-y-scroll px-4 text-2xl">
                   <div className="flex w-full flex-col gap-4">
-                    {postQuery.data?.map((p) => {
-                      return (
-                        <PostCard
-                          key={p.id}
-                          post={p}
-                          onPostDelete={() => deletePostMutation.mutate(p.id)}
-                        />
-                      );
-                    })}
+                    {postQuery.data?.map(
+                      (p: { id: string; title: string; content: string }) => {
+                        return (
+                          <PostCard
+                            key={p.id}
+                            post={p}
+                            onPostDelete={() => deletePostMutation.mutate(p.id)}
+                          />
+                        );
+                      },
+                    )}
                   </div>
                 </div>
               )}
@@ -134,7 +136,7 @@ const Home: NextPage = () => {
 
 export default Home;
 
-const AuthShowcase: React.FC = () => {
+function AuthShowcase() {
   const { data: session } = api.auth.getSession.useQuery();
 
   const { data: secretMessage } = api.auth.getSecretMessage.useQuery(
@@ -158,4 +160,4 @@ const AuthShowcase: React.FC = () => {
       </button>
     </div>
   );
-};
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 importers:
 


### PR DESCRIPTION
Remove React.FC usage in templates, replacing with standard function syntax as per Cje tweet https://twitter.com/ccccjjjjeeee/status/1668694515484336145