### PR TITLE
lint files with the closest tsconfig.json

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,11 +6,7 @@ const config = {
   parserOptions: {
     ecmaVersion: "latest",
     tsconfigRootDir: __dirname,
-    project: [
-      "./tsconfig.json",
-      "./apps/*/tsconfig.json",
-      "./packages/*/tsconfig.json",
-    ],
+    project: true,
   },
   settings: {
     next: {


### PR DESCRIPTION
Fixes #414

From v5.52 onwards we can set `parserOptions.project = true` which automatically resolves with the closest tsconfig. Since t3-turbo is set up in a way where each tsconfig matches an entire subfolder, are there any downsides to this approach?

In addition to fixing the OOM issue, this seems to be significantly more performant. Compare linting the main branch of create-t3-turbo:

With the array form of `parserOptions.project`:
```
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:07.61
Maximum resident set size (kbytes): 1065032
```

With `parserOptions.project = true`:
```
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:03.98
Maximum resident set size (kbytes): 414444
```