### PR TITLE
feat: Credentials Authentication

### DIFF
--- a/apps/nextjs/src/app/page.tsx
+++ b/apps/nextjs/src/app/page.tsx
@@ -28,12 +28,20 @@ async function AuthShowcase() {
 
   if (!session) {
     return (
-      <SignIn
-        provider="discord"
-        className="rounded-full bg-white/10 px-10 py-3 font-semibold text-white no-underline transition hover:bg-white/20"
-      >
-        Sign in with Discord
-      </SignIn>
+      <div className="flex flex-row">
+        <SignIn
+          provider="discord"
+          className="rounded-full bg-white/10 px-10 py-3 font-semibold text-white no-underline transition hover:bg-white/20"
+        >
+          Sign in with Discord
+        </SignIn>
+        <SignIn
+          provider="email"
+          className="rounded-full bg-white/10 px-10 py-3 font-semibold text-white no-underline transition hover:bg-white/20"
+        >
+          Sign in with Email
+        </SignIn>
+      </div>
     );
   }
 

--- a/apps/nextjs/src/components/auth.tsx
+++ b/apps/nextjs/src/components/auth.tsx
@@ -8,7 +8,11 @@ export function SignIn({
   ...props
 }: { provider: OAuthProviders } & ComponentProps<"button">) {
   return (
-    <form action={`/api/auth/signin/${provider}`} method="post">
+    <form
+      action={`/api/auth/signin/${provider}`}
+      method="post"
+      className="px-2"
+    >
       <button {...props} />
       <CSRF_experimental />
     </form>

--- a/packages/auth/env.mjs
+++ b/packages/auth/env.mjs
@@ -3,8 +3,8 @@ import { z } from "zod";
 
 export const env = createEnv({
   server: {
-    DISCORD_CLIENT_ID: z.string().min(1),
-    DISCORD_CLIENT_SECRET: z.string().min(1),
+    DISCORD_CLIENT_ID: z.string(),
+    DISCORD_CLIENT_SECRET: z.string(),
     NEXTAUTH_SECRET:
       process.env.NODE_ENV === "production"
         ? z.string().min(1)

--- a/packages/auth/index.ts
+++ b/packages/auth/index.ts
@@ -1,7 +1,13 @@
+import { randomUUID } from "crypto";
 import Discord from "@auth/core/providers/discord";
 import type { DefaultSession } from "@auth/core/types";
 import { PrismaAdapter } from "@auth/prisma-adapter";
+import { Prisma } from "@prisma/client";
+import bcrypt from "bcrypt";
 import NextAuth from "next-auth";
+import type { Session, SessionStrategy, TokenSet } from "next-auth/core/types";
+import CredentialsProvider from "next-auth/providers/credentials";
+import isEmail from "validator/lib/isEmail";
 
 import { prisma } from "@acme/db";
 
@@ -9,9 +15,10 @@ import { env } from "./env.mjs";
 
 export type { Session } from "next-auth";
 
-// Update this whenever adding new providers so that the client can
-export const providers = ["discord"] as const;
+export const providers = ["email", "discord"] as const;
 export type OAuthProviders = (typeof providers)[number];
+
+const client = PrismaAdapter(prisma);
 
 declare module "next-auth" {
   interface Session {
@@ -21,19 +28,85 @@ declare module "next-auth" {
   }
 }
 
-export const {
-  handlers: { GET, POST },
-  auth,
-  CSRF_experimental,
-} = NextAuth({
-  adapter: PrismaAdapter(prisma),
+const maxAge = 30 * 24 * 60 * 60; // 30 days
+
+const authorize = async (credentials) => {
+  const { email, password } = credentials;
+  let user;
+
+  try {
+    if (!isEmail(email)) {
+      throw new Error("Email should be a valid email address");
+    }
+    user = await client.getUserByEmail(email);
+    if (!user) {
+      user = await client.createUser({
+        email,
+        password: bcrypt.hashSync(password, 10),
+      });
+    } else {
+      const passwordsMatch = await bcrypt.compare(password, user.password);
+      if (!passwordsMatch) {
+        throw new Error("Password is not correct");
+      }
+    }
+    const token = randomUUID();
+    await client.createSession({
+      userId: user.id,
+      expires: new Date(Date.now() + maxAge * 1000),
+      sessionToken: token,
+    });
+    return {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      image: user.image,
+      sessionToken: token,
+    };
+  } catch (error) {
+    console.error(error.message);
+    throw error;
+  }
+};
+
+const EmailCredentials = CredentialsProvider({
+  name: "email",
+  credentials: {
+    email: { label: "Email", type: "text" },
+    password: { label: "Password", type: "password" },
+  },
+  authorize,
+});
+
+export const authOptions = {
+  secret: env.NEXTAUTH_SECRET,
+  adapter: client,
   providers: [
+    EmailCredentials,
     Discord({
       clientId: env.DISCORD_CLIENT_ID,
       clientSecret: env.DISCORD_CLIENT_SECRET,
     }),
   ],
+  session: {
+    strategy: "jwt" as SessionStrategy,
+    maxAge: maxAge, // 30 days
+    updateAge: 24 * 60 * 60, // 24 hours
+  },
   callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.userId = user.id;
+        token.sessionToken = user.sessionToken;
+      }
+      if (token?.sessionToken) {
+        const { session } = await client.getSessionAndUser(token.sessionToken);
+        if (!session) {
+          return null;
+        }
+      }
+      return token;
+    },
     session: ({ session, user }) => ({
       ...session,
       user: {
@@ -56,4 +129,17 @@ export const {
     //   return !!auth?.user
     // }
   },
-});
+  events: {
+    signOut: async ({ token, session }) => {
+      if (token?.sessionToken) {
+        await client.deleteSession(token.sessionToken);
+      }
+    },
+  },
+};
+
+export const {
+  handlers: { GET, POST },
+  auth,
+  CSRF_experimental,
+} = NextAuth(authOptions);

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -15,10 +15,12 @@
     "@auth/core": "^0.9.0",
     "@auth/prisma-adapter": "^1.0.1",
     "@t3-oss/env-nextjs": "^0.6.0",
+    "bcrypt": "^5.1.0",
     "next": "^13.4.12",
     "next-auth": "^0.0.0-manual.83c4ebd1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "validator": "^13.9.0",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -51,6 +51,7 @@ model User {
     name          String?
     email         String?   @unique
     emailVerified DateTime?
+    password      String?
     image         String?
     accounts      Account[]
     sessions      Session[]


### PR DESCRIPTION
This PR adds email / password authentication to create-t3-turbo using the NextAuth Credentials Provider.

Although NextJS discourages password authentication, for companies with an existing user base with existing credentials, it is difficult to not support password authentication. NextAuth also attempts to disable database sessions if using the Credentials Provider.

This PR demonstrates how to use the NextAuth Credential Provider to create JWT tokens **and** Database sessions.

The `authorize` method validates the email, hashes the password with bcrypt, compares password hashes, creates a database session, and returns the user object and sessionToken.

The `jwt` callback is used to add the sessionToken to the token object used to generate the JWT, tying the JWT to the database session, and validates the current JWT token against the database.

A `signOut` event is used delete the session from the database if the sessionToken is present in the JWT.

This should work with additional providers such as discord.