### PR TITLE
Change path in vscode settings file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
     { "pattern": "apps/*/" },
     { "pattern": "packages/*/" }
   ],
-  "tailwindCSS.experimental.configFile": "./packages/config/tailwind/index.ts",
+  "tailwindCSS.experimental.configFile": "./tooling/tailwind/index.ts",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.preferences.autoImportFileExcludePatterns": [


### PR DESCRIPTION
"Resolve Tailwind CSS Autocompletion Issue Caused by Hardcoded Paths in .vscode/settings.json

Description:
After recent updates, the Tailwind CSS autocompletion feature in Visual Studio Code has stopped functioning. This issue was traced back to hardcoded paths within the .vscode/settings.json configuration file.