### PR TITLE
fix(api): Make delete post endpoint protected

### DIFF
--- a/packages/api/src/router/post.ts
+++ b/packages/api/src/router/post.ts
@@ -34,7 +34,7 @@ export const postRouter = createTRPCRouter({
       return ctx.db.insert(schema.post).values(input);
     }),
 
-  delete: publicProcedure.input(z.number()).mutation(({ ctx, input }) => {
+  delete: protectedProcedure.input(z.number()).mutation(({ ctx, input }) => {
     return ctx.db.delete(schema.post).where(eq(schema.post.id, input));
   }),
 });


### PR DESCRIPTION
I think the delete post endpoint should be protected. 
It would also serve as a better example for the example.