### PR TITLE
Add `android.package` to Expo app config

### DIFF
--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -18,10 +18,11 @@ const defineConfig = (): ExpoConfig => ({
   },
   assetBundlePatterns: ["**/*"],
   ios: {
-    supportsTablet: true,
     bundleIdentifier: "your.bundle.identifier",
+    supportsTablet: true,
   },
   android: {
+    package: "your.bundle.identifier",
     adaptiveIcon: {
       foregroundImage: "./assets/icon.png",
       backgroundColor: "#1F104A",


### PR DESCRIPTION
Added `android.package` to Expo app config as it is needed for Android builds. Since `ios.identifier` is present, `android.package` should also be present.