### PR TITLE
Update id_token data type to work with Google Provider

### DIFF
--- a/packages/db/schema/auth.ts
+++ b/packages/db/schema/auth.ts
@@ -4,6 +4,7 @@ import {
   index,
   int,
   primaryKey,
+  text,
   timestamp,
   varchar,
 } from "drizzle-orm/mysql-core";
@@ -39,7 +40,7 @@ export const accounts = mySqlTable(
     expires_at: int("expires_at"),
     token_type: varchar("token_type", { length: 255 }),
     scope: varchar("scope", { length: 255 }),
-    id_token: text('id_token'),
+    id_token: text("id_token"),
     session_state: varchar("session_state", { length: 255 }),
   },
   (account) => ({

--- a/packages/db/schema/auth.ts
+++ b/packages/db/schema/auth.ts
@@ -39,7 +39,7 @@ export const accounts = mySqlTable(
     expires_at: int("expires_at"),
     token_type: varchar("token_type", { length: 255 }),
     scope: varchar("scope", { length: 255 }),
-    id_token: varchar("id_token", { length: 255 }),
+    id_token: text('id_token'),
     session_state: varchar("session_state", { length: 255 }),
   },
   (account) => ({


### PR DESCRIPTION
Updating the data type to `text` fixes the Google Provider issue

This is also how it is configured in the next auth [prisma adapter](https://authjs.dev/reference/adapter/prisma#create-the-prisma-schema-from-scratch) with the following note for MySQL:
> When using the MySQL connector for Prisma, the [Prisma String type](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#string) gets mapped to varchar(191) which may not be long enough to store fields such as id_token in the Account model. This can be avoided by explicitly using the Text type with @db.Text.


fixes #585 