### PR TITLE
Specify foreign key for sessionsRelations

### DIFF
--- a/packages/db/schema/auth.ts
+++ b/packages/db/schema/auth.ts
@@ -68,7 +68,7 @@ export const sessions = mySqlTable(
 );
 
 export const sessionsRelations = relations(sessions, ({ one }) => ({
-  user: one(users),
+  user: one(users, { fields: [sessions.userId], references: [users.id] }),
 }));
 
 export const verificationTokens = mySqlTable(


### PR DESCRIPTION
Otherwise Drizzle cannot infer the type of session.user (or t3turbo_session.user).

This error also prevents the programmer from being able to access Drizzle studio