### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 # @link https://turborepo.org/docs/core-concepts/remote-caching#remote-caching-on-vercel-builds
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
 jobs:
   build-lint:


### PR DESCRIPTION
Updated ci.yml to use "vars.TURBO_TEAM" instead of "secrets.TURBO_TEAM" so that caching works when using the setup described in the turborepo docs:

https://turbo.build/repo/docs/ci/github-actions

I spent an hour trying to figure out why caching wasn't working and found that these 2 things differt. The TURBO_TOKEN is still setup as a secret