### PR TITLE
run manypkg check postinstall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,3 @@ jobs:
 
       - name: Build, lint and type-check
         run: pnpm turbo build lint format typecheck
-
-      - name: Check workspaces
-        run: pnpm manypkg check

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "turbo build",
     "clean": "git clean -xdf node_modules",
     "clean:workspaces": "turbo clean",
+    "postinstall": "manypkg check",
     "db:push": "pnpm -F db push",
     "db:studio": "pnpm -F db studio",
     "dev": "turbo dev --parallel",


### PR DESCRIPTION
Run `manypkg check` on `postinstall` to catch dependency issues as early as possible and not only in ci.

Also removed `Check workspaces` step from ci workflow since check runs after `pnpm install` with this change.