### PR TITLE
fix: turbo generator still used manypkg

### DIFF
--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -72,7 +72,7 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
          * Install deps and format everything
          */
         if ("name" in answers && typeof answers.name === "string") {
-          execSync("pnpm manypkg fix", {
+          execSync("pnpm dlx sherif@latest --fix", {
             stdio: "inherit",
           });
           execSync(

--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -1,5 +1,12 @@
 import { execSync } from "node:child_process";
-import type { PackageJson, PlopTypes } from "@turbo/gen";
+import type { PlopTypes } from "@turbo/gen";
+
+interface PackageJson {
+  name: string;
+  scripts: Record<string, string>;
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+}
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
   plop.setGenerator("init", {

--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -72,9 +72,10 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
          * Install deps and format everything
          */
         if ("name" in answers && typeof answers.name === "string") {
-          execSync("pnpm dlx sherif@latest --fix", {
-            stdio: "inherit",
-          });
+          // execSync("pnpm dlx sherif@latest --fix", {
+          //   stdio: "inherit",
+          // });
+          execSync("pnpm i", { stdio: "inherit" });
           execSync(
             `pnpm prettier --write packages/${answers.name}/** --list-different`,
           );

--- a/turbo/generators/templates/package.json.hbs
+++ b/turbo/generators/templates/package.json.hbs
@@ -19,14 +19,12 @@
     "format": "prettier --check \"**/*.{mjs,ts,md,json}\"",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-  },
   "devDependencies": {
     "@acme/eslint-config": "workspace:^0.2.0",
     "@acme/prettier-config": "workspace:^0.1.0",
     "@acme/tsconfig": "workspace:^0.1.0",
-    "eslint": "^8.47.0",
-    "typescript": "^5.1.6"
+    "eslint": "^8.53.0",
+    "typescript": "^5.2.2"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
The turbo generator still uses `manypkg` package. The pacakge was removed in PR #717 

Migrate used `manypkg` command to `sherif`.

If you create a new package the command throws an error because of the the [rules](https://www.npmjs.com/package/sherif#rules) integrated in sherif and used package versions in the workspaces.

Sample output:
```
❯ pnpm turbo gen init

>>> Modify "create-t3-turbo" using custom generators

? What is the name of the package? (You can skip the `@acme/` prefix) test
? Enter a space separated list of dependencies you would like to install
Packages: +2
++
Progress: resolved 7, reused 2, downloaded 0, added 2, done

1 issue found in ./packages/test/package.json:

 ✓ fixed package.json should not have empty dependencies fields. empty-dependencies
  │ {
  -   "dependencies": {}   ← field is empty.
  │ }

2 issues found in ./:

 ⨯ error Dependency eslint has multiple versions defined in the workspace. multiple-dependency-versions
  ./packages
      test            ^8.47.0   ↓ lowest
  ./apps
      auth-proxy      ^8.53.0   ↑ highest
      expo            ^8.53.0   ↑ highest
      nextjs          ^8.53.0   ↑ highest
  ./packages
      api             ^8.53.0   ↑ highest
      auth            ^8.53.0   ↑ highest
      db              ^8.53.0   ↑ highest
  ./tooling
      eslint          ^8.53.0   ↑ highest
      tailwind        ^8.53.0   ↑ highest

 ⨯ error Dependency typescript has multiple versions defined in the workspace. multiple-dependency-versions
  ./packages
      test            ^5.1.6   ↓ lowest
  ./apps
      auth-proxy      ^5.2.2   ↑ highest
      expo            ^5.2.2   ↑ highest
      nextjs          ^5.2.2   ↑ highest
  ./packages
      api             ^5.2.2   ↑ highest
      auth            ^5.2.2   ↑ highest
      db              ^5.2.2   ↑ highest
  ./tooling
      eslint          ^5.2.2   ↑ highest
      prettier        ^5.2.2   ↑ highest
      tailwind        ^5.2.2   ↑ highest

3 issues found (2 ⨯, 0 ⚠️, 1 ✓) across 12 packages in 1.208417ms.
 Note: use `-i` to ignore dependencies, `-r` to ignore rules, `-p` to ignore packages, and `--fix` to autofix fixable issues.
>>> Error - Command failed: pnpm dlx sherif@latest --fix. Unable to function to ""

>>> Failed to run "init" generator
```

Maybe it is a good idea to disable the [multiple-dependeny-versions rule](https://www.npmjs.com/package/sherif#multiple-dependency-versions-)?