### PR TITLE
implement react native compatible logger

### DIFF
--- a/apps/expo/src/utils/api.tsx
+++ b/apps/expo/src/utils/api.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Constants from "expo-constants";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { httpBatchLink } from "@trpc/client";
+import { httpBatchLink, loggerLink } from "@trpc/client";
 import { createTRPCReact } from "@trpc/react-query";
 import superjson from "superjson";
 
@@ -57,6 +57,12 @@ export function TRPCProvider(props: { children: React.ReactNode }) {
             headers.set("x-trpc-source", "expo-react");
             return Object.fromEntries(headers);
           },
+        }),
+        loggerLink({
+          enabled: (opts) =>
+            process.env.NODE_ENV === "development" ||
+            (opts.direction === "down" && opts.result instanceof Error),
+          colorMode: "ansi",
         }),
       ],
     }),


### PR DESCRIPTION
The logger is an important feature of TRPC, especially in RN since the network inspector isn't that great so it's nice to have correct defaults. It can be disabled at anytime.
The loggerLink uses CSS mode by default which breaks some log messages in react native.
This PR addresses this issue.
Mentioned in https://github.com/trpc/trpc/issues/2898
enabled check is taken from the official t3 stack [template](https://github.com/t3-oss/create-t3-app/blob/9eac8f5cb220b00261e4151e596ba7efa3e398b5/cli/template/extras/src/utils/api.ts#L38C14-L38C14).