### PR TITLE
static-test

### DIFF
--- a/apps/nextjs/next.config.js
+++ b/apps/nextjs/next.config.js
@@ -7,6 +7,9 @@ const config = {
   reactStrictMode: true,
   /** Enables hot reloading for local packages without a build step */
   transpilePackages: ["@acme/api", "@acme/auth", "@acme/db"],
+  // experimental: {
+  //   ppr: true,
+  // },
   /** We already do linting and typechecking as separate tasks in CI */
   eslint: { ignoreDuringBuilds: true },
   typescript: { ignoreBuildErrors: true },

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -25,7 +25,7 @@
     "@trpc/next": "next",
     "@trpc/react-query": "next",
     "@trpc/server": "next",
-    "next": "^14.0.4",
+    "next": "canary",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "superjson": "2.2.1",

--- a/apps/nextjs/src/app/static-test/page.tsx
+++ b/apps/nextjs/src/app/static-test/page.tsx
@@ -1,0 +1,3 @@
+export default function StaticPage() {
+  return <div>I am fully static</div>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,13 +189,13 @@ importers:
         version: 5.8.7(@tanstack/react-query@5.8.7)(react-dom@18.2.0)(react@18.2.0)
       '@tanstack/react-query-next-experimental':
         specifier: 5.8.7
-        version: 5.8.7(@tanstack/react-query@5.8.7)(next@14.0.4)(react-dom@18.2.0)(react@18.2.0)
+        version: 5.8.7(@tanstack/react-query@5.8.7)(next@14.0.5-canary.28)(react-dom@18.2.0)(react@18.2.0)
       '@trpc/client':
         specifier: next
         version: 11.0.0-alpha-next-2023-12-18-04-17-50.120(@trpc/server@11.0.0-alpha-next-2023-12-18-04-17-50.120)
       '@trpc/next':
         specifier: next
-        version: 11.0.0-alpha-next-2023-12-18-04-17-50.120(@tanstack/react-query@5.8.7)(@trpc/client@11.0.0-alpha-next-2023-12-18-04-17-50.120)(@trpc/react-query@11.0.0-alpha-next-2023-12-18-04-17-50.120)(@trpc/server@11.0.0-alpha-next-2023-12-18-04-17-50.120)(next@14.0.4)(react-dom@18.2.0)(react@18.2.0)
+        version: 11.0.0-alpha-next-2023-12-18-04-17-50.120(@tanstack/react-query@5.8.7)(@trpc/client@11.0.0-alpha-next-2023-12-18-04-17-50.120)(@trpc/react-query@11.0.0-alpha-next-2023-12-18-04-17-50.120)(@trpc/server@11.0.0-alpha-next-2023-12-18-04-17-50.120)(next@14.0.5-canary.28)(react-dom@18.2.0)(react@18.2.0)
       '@trpc/react-query':
         specifier: next
         version: 11.0.0-alpha-next-2023-12-18-04-17-50.120(@tanstack/react-query@5.8.7)(@trpc/client@11.0.0-alpha-next-2023-12-18-04-17-50.120)(@trpc/server@11.0.0-alpha-next-2023-12-18-04-17-50.120)(react-dom@18.2.0)(react@18.2.0)
@@ -203,8 +203,8 @@ importers:
         specifier: next
         version: 11.0.0-alpha-next-2023-12-18-04-17-50.120
       next:
-        specifier: ^14.0.4
-        version: 14.0.4(react-dom@18.2.0)(react@18.2.0)
+        specifier: canary
+        version: 14.0.5-canary.28(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -3116,6 +3116,10 @@ packages:
     resolution: {integrity: sha512-irQnbMLbUNQpP1wcE5NstJtbuA/69kRfzBrpAD7Gsn8zm/CY6YQYc3HQBz8QPxwISG26tIm5afvvVbu508oBeQ==}
     dev: false
 
+  /@next/env@14.0.5-canary.28:
+    resolution: {integrity: sha512-qDD1MypbRDWPtYEf5FcwnPQXYSmAKx5sNAnq+3nKGmBdu0GbH3GXJToFJZn6ble6dIngJklAsn/w7xo9en2gQw==}
+    dev: false
+
   /@next/eslint-plugin-next@14.0.4:
     resolution: {integrity: sha512-U3qMNHmEZoVmHA0j/57nRfi3AscXNvkOnxDmle/69Jz/G0o/gWjXTDdlgILZdrxQ0Lw/jv2mPW8PGy0EGIHXhQ==}
     dependencies:
@@ -3124,6 +3128,15 @@ packages:
 
   /@next/swc-darwin-arm64@14.0.4:
     resolution: {integrity: sha512-mF05E/5uPthWzyYDyptcwHptucf/jj09i2SXBPwNzbgBNc+XnwzrL0U6BmPjQeOL+FiB+iG1gwBeq7mlDjSRPg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-darwin-arm64@14.0.5-canary.28:
+    resolution: {integrity: sha512-835xTkuQ8Y1SUip9WLEZcxfdc5cbGG8Ot0H+QtELgnPxTWBuA3U/v7jIxLYUXitFUwzmWQaWluHFtE/FKCqAtQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -3140,8 +3153,26 @@ packages:
     dev: false
     optional: true
 
+  /@next/swc-darwin-x64@14.0.5-canary.28:
+    resolution: {integrity: sha512-VsRQfyudlPL77KkjWq4HuYBbd32pteVt8Q5BdNw6pNGAfQsOtZ5axAfOuAwRlelYHVlKjB3pxpTKlEpht1nfXg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@next/swc-linux-arm64-gnu@14.0.4:
     resolution: {integrity: sha512-VwwZKrBQo/MGb1VOrxJ6LrKvbpo7UbROuyMRvQKTFKhNaXjUmKTu7wxVkIuCARAfiI8JpaWAnKR+D6tzpCcM4w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-arm64-gnu@14.0.5-canary.28:
+    resolution: {integrity: sha512-dIPclhG0ICnVqinsyjBQRBB7WHVLhI7M/dwSR5QKSp6q9pi86O+aXbH2wxs29pg6clFPlEy4XH4sCgJgNHTY7g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -3158,8 +3189,26 @@ packages:
     dev: false
     optional: true
 
+  /@next/swc-linux-arm64-musl@14.0.5-canary.28:
+    resolution: {integrity: sha512-WRNWalDdnKk8GxeQ3loRfm5UJNZzVhAmXeG8XfsLTwJrDiO9V10IH4cxKuTID7Na7zpv/D8zZFs4xnLUl2KynQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@next/swc-linux-x64-gnu@14.0.4:
     resolution: {integrity: sha512-/s/Pme3VKfZAfISlYVq2hzFS8AcAIOTnoKupc/j4WlvF6GQ0VouS2Q2KEgPuO1eMBwakWPB1aYFIA4VNVh667A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-x64-gnu@14.0.5-canary.28:
+    resolution: {integrity: sha512-KYMz7jJ8rhq6sfbUtWXR5QdngIOTcB+Pu2s/gWOODlrlCv/ifMV+Jr/WWkfgwpxv235515oEqYpXjIArwI/j9w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -3176,8 +3225,26 @@ packages:
     dev: false
     optional: true
 
+  /@next/swc-linux-x64-musl@14.0.5-canary.28:
+    resolution: {integrity: sha512-GBqfGCgBuy9SwDvLH+a6X9DRb7l0UMw1F2k1Bm/KXr8yxxfxMmzYVBCTXTB1hzvBvRviLTqPgedaQfqEvCKrnA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@next/swc-win32-arm64-msvc@14.0.4:
     resolution: {integrity: sha512-7Wv4PRiWIAWbm5XrGz3D8HUkCVDMMz9igffZG4NB1p4u1KoItwx9qjATHz88kwCEal/HXmbShucaslXCQXUM5w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-win32-arm64-msvc@14.0.5-canary.28:
+    resolution: {integrity: sha512-wdFExeiSuov0502SQSxmMpns2R8OkY37IL9AnQnJ7/rOSwFY95G919dCUHxfulozPgbJqYej78aomKmk+ovxsA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -3194,8 +3261,26 @@ packages:
     dev: false
     optional: true
 
+  /@next/swc-win32-ia32-msvc@14.0.5-canary.28:
+    resolution: {integrity: sha512-n7vDtTbEYXkYCo/j8vsymKMygt5mMqd5YY3xC7RWDhQsuRjrA7a78GEIuVvViAHe7ckrpXjlbdb5gtjWV9LBnQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@next/swc-win32-x64-msvc@14.0.4:
     resolution: {integrity: sha512-yEh2+R8qDlDCjxVpzOTEpBLQTEFAcP2A8fUFLaWNap9GitYKkKv1//y2S6XY6zsR4rCOPRpU7plYDR+az2n30A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-win32-x64-msvc@14.0.5-canary.28:
+    resolution: {integrity: sha512-5QQpjuoYbUI609HfgMqA3vn9ffxozMc2nRa05SdQR5+V05AVWocziwNUf3bN7db0VYvcbV3o7COrpreizcINGg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -4202,7 +4287,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@tanstack/react-query-next-experimental@5.8.7(@tanstack/react-query@5.8.7)(next@14.0.4)(react-dom@18.2.0)(react@18.2.0):
+  /@tanstack/react-query-next-experimental@5.8.7(@tanstack/react-query@5.8.7)(next@14.0.5-canary.28)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-ZOhcgG2EsQVI8QLA7xOoYX7rXpVq33lNzgTsDboTD7RTsNQ7Lq7nE/u9YQDf+1bnABTkuZtAjCUDOfm/7BN/qQ==}
     peerDependencies:
       '@tanstack/react-query': ^5.8.7
@@ -4211,7 +4296,7 @@ packages:
       react-dom: ^18.0.0
     dependencies:
       '@tanstack/react-query': 5.8.7(react-dom@18.2.0)(react-native@0.73.0)(react@18.2.0)
-      next: 14.0.4(react-dom@18.2.0)(react@18.2.0)
+      next: 14.0.5-canary.28(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -4246,7 +4331,7 @@ packages:
       '@trpc/server': 11.0.0-alpha-next-2023-12-18-04-17-50.120
     dev: false
 
-  /@trpc/next@11.0.0-alpha-next-2023-12-18-04-17-50.120(@tanstack/react-query@5.8.7)(@trpc/client@11.0.0-alpha-next-2023-12-18-04-17-50.120)(@trpc/react-query@11.0.0-alpha-next-2023-12-18-04-17-50.120)(@trpc/server@11.0.0-alpha-next-2023-12-18-04-17-50.120)(next@14.0.4)(react-dom@18.2.0)(react@18.2.0):
+  /@trpc/next@11.0.0-alpha-next-2023-12-18-04-17-50.120(@tanstack/react-query@5.8.7)(@trpc/client@11.0.0-alpha-next-2023-12-18-04-17-50.120)(@trpc/react-query@11.0.0-alpha-next-2023-12-18-04-17-50.120)(@trpc/server@11.0.0-alpha-next-2023-12-18-04-17-50.120)(next@14.0.5-canary.28)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-5JzHF6gdMX9O3MjnzYMHQohHDVN+3+z/exqqRLuU7+hNU17BhacERxrxYYYUDLvbeCk2uq+DgVdjzLKPrqZMOg==}
     peerDependencies:
       '@tanstack/react-query': ^5.0.0
@@ -4261,7 +4346,7 @@ packages:
       '@trpc/client': 11.0.0-alpha-next-2023-12-18-04-17-50.120(@trpc/server@11.0.0-alpha-next-2023-12-18-04-17-50.120)
       '@trpc/react-query': 11.0.0-alpha-next-2023-12-18-04-17-50.120(@tanstack/react-query@5.8.7)(@trpc/client@11.0.0-alpha-next-2023-12-18-04-17-50.120)(@trpc/server@11.0.0-alpha-next-2023-12-18-04-17-50.120)(react-dom@18.2.0)(react@18.2.0)
       '@trpc/server': 11.0.0-alpha-next-2023-12-18-04-17-50.120
-      next: 14.0.4(react-dom@18.2.0)(react@18.2.0)
+      next: 14.0.5-canary.28(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-ssr-prepass: 1.5.0(react@18.2.0)
@@ -10211,6 +10296,46 @@ packages:
       '@next/swc-win32-arm64-msvc': 14.0.4
       '@next/swc-win32-ia32-msvc': 14.0.4
       '@next/swc-win32-x64-msvc': 14.0.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    dev: false
+
+  /next@14.0.5-canary.28(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-yOYNfSTK1Id2WGro0TGt0Q5zfEJGduISIGYeOEYWIUtSZDOqi8llx5iP/tzWUYwRfSrswgnNurDiZd8KT9XbqA==}
+    engines: {node: '>=18.17.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 14.0.5-canary.28
+      '@swc/helpers': 0.5.2
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001551
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      styled-jsx: 5.1.1(react@18.2.0)
+      watchpack: 2.4.0
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.0.5-canary.28
+      '@next/swc-darwin-x64': 14.0.5-canary.28
+      '@next/swc-linux-arm64-gnu': 14.0.5-canary.28
+      '@next/swc-linux-arm64-musl': 14.0.5-canary.28
+      '@next/swc-linux-x64-gnu': 14.0.5-canary.28
+      '@next/swc-linux-x64-musl': 14.0.5-canary.28
+      '@next/swc-win32-arm64-msvc': 14.0.5-canary.28
+      '@next/swc-win32-ia32-msvc': 14.0.5-canary.28
+      '@next/swc-win32-x64-msvc': 14.0.5-canary.28
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros


### PR DESCRIPTION
Demo of trying to pass SSRed headers to client component to support authenticated requests from CCs during SSR:

Current build outputs this:

```sh
Route (app)                              Size     First Load JS
┌ ℇ /                                    1.56 kB         109 kB
├ λ /_not-found                          881 B          84.5 kB        <--- dynamic
├ ℇ /api/auth/[...nextauth]              0 B                0 B
├ ℇ /api/trpc/[trpc]                     0 B                0 B
└ λ /static-test                         138 B          83.7 kB        <--- dynamic
+ First Load JS shared by all            83.6 kB
  ├ chunks/1dd3208c-768f7900c6708cf1.js  53.3 kB
  ├ chunks/592-504263389c135037.js       28.4 kB
  ├ chunks/main-app-81eb073867dbb746.js  241 B
  └ chunks/webpack-b21e84f38b8029f1.js   1.71 kB
```

Changing `getHeaders` as follows:

```diff
- const getHeaders = cache(() => Promise.resolve(headers()));
+ const getHeaders = cache(() => Promise.resolve({} as any));
```

> FYI, the promise is awaited here: https://github.com/t3-oss/create-t3-turbo/blob/50608c2bde822c38ed3937d9cb70abb2ec53bc8e/apps/nextjs/src/trpc/react.tsx#L31 tRPC invokes [the headers function](https://github.com/t3-oss/create-t3-turbo/blob/50608c2bde822c38ed3937d9cb70abb2ec53bc8e/apps/nextjs/src/trpc/react.tsx#L30-L34) whenever a request is made, i.e. only in components that use `useQuery`, for example here: https://github.com/t3-oss/create-t3-turbo/blob/50608c2bde822c38ed3937d9cb70abb2ec53bc8e/apps/nextjs/src/app/_components/posts.tsx#L75

yields this build output:

```sh
Route (app)                              Size     First Load JS
┌ ℇ /                                    1.56 kB         109 kB
├ ○ /_not-found                          881 B          84.5 kB        <--- static
├ ℇ /api/auth/[...nextauth]              0 B                0 B
├ ℇ /api/trpc/[trpc]                     0 B                0 B
└ ○ /static-test                         138 B          83.7 kB        <--- static
+ First Load JS shared by all            83.6 kB
  ├ chunks/1dd3208c-768f7900c6708cf1.js  53.3 kB
  ├ chunks/592-504263389c135037.js       28.4 kB
  ├ chunks/main-app-81eb073867dbb746.js  241 B
  └ chunks/webpack-b21e84f38b8029f1.js   1.71 kB
```

i.e. passing the headers as a promise and not unwrapping it still doesn't support rendering pages statically. Turning on `ppr` in next config makes the `_not-found` static, but not the `/static-test`:

```sh
Route (app)                              Size     First Load JS
┌ ℇ /                                    1.55 kB         111 kB
├ ○ /_not-found                          879 B            86 kB        <--- static
├ ℇ /api/auth/[...nextauth]              0 B                0 B
├ ℇ /api/trpc/[trpc]                     0 B                0 B
└ λ /static-test                         138 B          85.2 kB        <--- dynamic
+ First Load JS shared by all            85.1 kB
  ├ chunks/574-82d3b913dc8c3287.js       29.2 kB
  ├ chunks/8593596e-4bb26bb9ca147299.js  53.9 kB
  ├ chunks/main-app-64cd6d7e06d93ea0.js  241 B
  └ chunks/webpack-b21e84f38b8029f1.js   1.71 kB
```

Any ideas how to get `/static-test` to be static, whilst still letting CCs having access to headers during SSR where needed?
