### PR TITLE
fix: wrong column type for access_token

### DIFF
--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -35,7 +35,7 @@ export const accounts = mySqlTable(
     provider: varchar("provider", { length: 255 }).notNull(),
     providerAccountId: varchar("providerAccountId", { length: 255 }).notNull(),
     refresh_token: varchar("refresh_token", { length: 255 }),
-    access_token: varchar("access_token", { length: 255 }),
+    access_token: text("access_token"),
     expires_at: int("expires_at"),
     token_type: varchar("token_type", { length: 255 }),
     scope: varchar("scope", { length: 255 }),


### PR DESCRIPTION
Fixes the issue

``` 
@acme/nextjs:dev: [auth][cause]: Error: Data too long for column 'access_token' at row 1
```

----

got this error while testing with azure ad - Now `id_token` and `access_token` have the same column type.