### PR TITLE
fix: update compoundKey to fix deprecation message

### DIFF
--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -43,7 +43,9 @@ export const accounts = mySqlTable(
     session_state: varchar("session_state", { length: 255 }),
   },
   (account) => ({
-    compoundKey: primaryKey(account.provider, account.providerAccountId),
+    compoundKey: primaryKey({
+      columns: [account.provider, account.providerAccountId],
+    }),
     userIdIdx: index("userId_idx").on(account.userId),
   }),
 );
@@ -78,6 +80,6 @@ export const verificationTokens = mySqlTable(
     expires: timestamp("expires", { mode: "date" }).notNull(),
   },
   (vt) => ({
-    compoundKey: primaryKey(vt.identifier, vt.token),
+    compoundKey: primaryKey({ columns: [vt.identifier, vt.token] }),
   }),
 );


### PR DESCRIPTION
Fixes the following deprecation warning:

```
@deprecated — : Please use primaryKey({ columns: [] }) instead of this function
```

Ref: https://github.com/drizzle-team/drizzle-orm/releases/tag/0.29.0