### PR TITLE
fix: react-native version

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -30,7 +30,7 @@
     "nativewind": "^4.0.22",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-native": "0.73.1",
+    "react-native": "~0.72.10",
     "react-native-gesture-handler": "~2.12.0",
     "react-native-reanimated": "~3.3.0",
     "react-native-safe-area-context": "4.6.3",


### PR DESCRIPTION
It looks like Expo SDK 49 only supports React Native version 0.72.
https://docs.expo.dev/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version
Closes #839 while the starter repo updates to Expo SDK 50.

I've never used renovatebot, but the tilde should prevent any minor version updates.