### PR TITLE
fix(expo): Revert `node-linker=hoisted` change

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted


### PR DESCRIPTION
This PR reverts the removal of the .npmrc file because eas-cli doesn't play well with pnpm yet.
See more at https://github.com/t3-oss/create-t3-turbo/issues/867

Tried public-hoist-pattern with expo and eas-cli, but the eas build command still fails because it cannot locate the metro config, a dead end.

