### PR TITLE
fixed jiti import for windows

### DIFF
--- a/apps/nextjs/next.config.js
+++ b/apps/nextjs/next.config.js
@@ -1,6 +1,11 @@
 import _jiti from "jiti";
 
-const jiti = _jiti(new URL(import.meta.url).pathname);
+let path = new URL(import.meta.url).pathname;
+
+if (process.platform === "win32") {
+  path = path.replace(/^\/(\w):/, "$1:");
+}
+const jiti = _jiti(path);
 
 // Import env files to validate at build time. Use jiti so we can load .ts files in here.
 jiti("./src/env");


### PR DESCRIPTION
Fixing issue: [bug: next.config.js fails jiti imports on windows. #885](https://github.com/t3-oss/create-t3-turbo/issues/885)