### PR TITLE
Change `/dist` category in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ next-env.d.ts
 
 # expo
 .expo/
-dist/
 expo-env.d.ts
 apps/expo/.gitignore
 
@@ -45,6 +44,7 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+dist/
 
 # turbo
 .turbo


### PR DESCRIPTION
Since the newest changes with `tsc` in this repo, `/dist` is not just about expo anymore. I couldn't decide between "production" and "typescript" categories. Would like your opinion.