### PR TITLE
Move `api` to `@acme/api`

### DIFF
--- a/apps/nextjs/src/app/_components/posts.tsx
+++ b/apps/nextjs/src/app/_components/posts.tsx
@@ -3,6 +3,7 @@
 import { use } from "react";
 
 import type { RouterOutputs } from "@acme/api";
+import { api } from "@acme/api/react";
 import { cn } from "@acme/ui";
 import { Button } from "@acme/ui/button";
 import {
@@ -16,8 +17,6 @@ import {
 import { Input } from "@acme/ui/input";
 import { toast } from "@acme/ui/toast";
 import { CreatePostSchema } from "@acme/validators";
-
-import { api } from "~/trpc/react";
 
 export function CreatePostForm() {
   const form = useForm({

--- a/apps/nextjs/src/trpc/react.tsx
+++ b/apps/nextjs/src/trpc/react.tsx
@@ -3,10 +3,9 @@
 import { useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { loggerLink, unstable_httpBatchStreamLink } from "@trpc/client";
-import { createTRPCReact } from "@trpc/react-query";
 import SuperJSON from "superjson";
 
-import type { AppRouter } from "@acme/api";
+import { api } from "@acme/api/react";
 
 const createQueryClient = () => new QueryClient();
 
@@ -20,8 +19,6 @@ const getQueryClient = () => {
     return (clientQueryClientSingleton ??= createQueryClient());
   }
 };
-
-export const api = createTRPCReact<AppRouter>();
 
 export function TRPCReactProvider(props: { children: React.ReactNode }) {
   const queryClient = getQueryClient();

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,6 +7,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./src/index.ts"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "default": "./src/react.ts"
     }
   },
   "license": "MIT",
@@ -22,6 +26,7 @@
     "@acme/auth": "workspace:*",
     "@acme/db": "workspace:*",
     "@acme/validators": "workspace:*",
+    "@trpc/react-query": "11.0.0-next.320",
     "@trpc/server": "11.0.0-next.320",
     "superjson": "2.2.1",
     "zod": "^3.22.4"

--- a/packages/api/src/react.ts
+++ b/packages/api/src/react.ts
@@ -1,0 +1,7 @@
+import { createTRPCReact } from "@trpc/react-query";
+
+import type { AppRouter } from "./root";
+
+const api = createTRPCReact<AppRouter>();
+
+export { api };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,9 @@ importers:
       '@acme/validators':
         specifier: workspace:*
         version: link:../validators
+      '@trpc/react-query':
+        specifier: 11.0.0-next.320
+        version: 11.0.0-next.320(@tanstack/react-query@5.28.6)(@trpc/client@11.0.0-next.320)(@trpc/server@11.0.0-next.320)(react-dom@18.2.0)(react@18.2.0)
       '@trpc/server':
         specifier: 11.0.0-next.320
         version: 11.0.0-next.320


### PR DESCRIPTION
By moving this line:

```ts
export const api = createTRPCReact<AppRouter>();
```

from `apps/nextjs/src/trpc/react.tsx` to `packages/api` we can make it usable in other React based packages that rely on API calls. Also reduces duplication in Next.js packages.