### PR TITLE
feat: multi-root workspaces

### DIFF
--- a/.vscode/create-t3-turbo.code-workspace
+++ b/.vscode/create-t3-turbo.code-workspace
@@ -1,0 +1,35 @@
+{
+  "folders": [
+    {
+      "name": "Next.js",
+      "path": "../apps/nextjs",
+    },
+    {
+      "name": "Expo",
+      "path": "../apps/expo",
+    },
+    {
+      "name": "Root",
+      "path": "../",
+    },
+  ],
+  "extensions": {
+    "recommendations": ["joshx.workspace-terminals"],
+  },
+  "settings": {
+    "search.useIgnoreFiles": true,
+    // use root .gitignore to ignore files from search
+    "search.useParentIgnoreFiles": true,
+  },
+  "launch": {
+    "version": "0.2.0",
+    "configurations": [],
+    "compounds": [
+      {
+        "name": "Launch Next.js and Expo",
+        // from apps/nextjs/.vscode/launch.json and apps/expo/.vscode/launch.json
+        "configurations": ["Debug Next.js", "Debug Expo app"],
+      },
+    ],
+  },
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,20 @@
       "command": "pnpm dev",
       "cwd": "${workspaceFolder}/apps/nextjs/",
       "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "name": "Expo",
+      "type": "expo",
+      "request": "attach",
+      "projectRoot": "${workspaceFolder}/apps/expo",
+      "bundlerPort": "8081",
+      "bundlerHost": "127.0.0.1"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Launch Next.js and Expo",
+      "configurations": ["Next.js", "Expo"]
     }
   ]
 }

--- a/apps/expo/.vscode/launch.json
+++ b/apps/expo/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "type": "expo",
+        "request": "attach",
+        "name": "Debug Expo app",
+        "projectRoot": "${workspaceFolder}",
+        "bundlerPort": "8081",
+        "bundlerHost": "127.0.0.1"
+      }
+    ]
+  }
+  

--- a/apps/nextjs/.vscode/launch.json
+++ b/apps/nextjs/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Debug Next.js",
+        "type": "node-terminal",
+        "request": "launch",
+        "command": "pnpm dev",
+        "cwd": "${workspaceFolder}",
+        "skipFiles": ["<node_internals>/**"]
+      }
+    ]
+  }
+  


### PR DESCRIPTION
https://code.visualstudio.com/docs/editor/multi-root-workspaces

I came across [next-fast-turbo](https://github.com/cording12/next-fast-turbo) when adding a FastAPI to a Turborepo, and I enjoyed the development experience of using multi-root workspaces. https://next-fast-turbo.mintlify.app/documentation/local-development#working-with-a-monorepo-in-vs-code

Any experience working with multi-root workspaces? One issue I noticed is that there is some overlap between the root `launch.json` configurations and the ones defined in `.code-workspace`. Leads to this when working in the multi-root workspace:

![image](https://github.com/t3-oss/create-t3-turbo/assets/24904780/a778092c-5e5e-4c1f-b7de-75ada0c776b6)

I don't have enough experience to say, but we could recommend multi-root workspaces in the README and then remove the root `launch.json`, but only if there are clear advantages to working with Turborepo in a multi-root workspace.

