### PR TITLE
Use .find() instead of always first cookie

### DIFF
--- a/apps/nextjs/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/nextjs/src/app/api/auth/[...nextauth]/route.ts
@@ -32,8 +32,10 @@ export const GET = async (
     cookies().delete(EXPO_COOKIE_NAME);
 
     const authResponse = await DEFAULT_GET(req);
-    const setCookie = authResponse.headers.getSetCookie()[0];
-    const match = setCookie?.match(AUTH_COOKIE_PATTERN)?.[1];
+    const match = authResponse.headers
+      .getSetCookie()
+      .find((c) => c.match(AUTH_COOKIE_PATTERN)?.[1]);
+      
     if (!match)
       throw new Error(
         "Unable to find session cookie: " +

--- a/apps/nextjs/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/nextjs/src/app/api/auth/[...nextauth]/route.ts
@@ -32,9 +32,10 @@ export const GET = async (
     cookies().delete(EXPO_COOKIE_NAME);
 
     const authResponse = await DEFAULT_GET(req);
-    const match = authResponse.headers
+    const setCookie = authResponse.headers
       .getSetCookie()
-      .find((c) => c.match(AUTH_COOKIE_PATTERN)?.[1]);
+      .find((cookie) => cookie.startsWith("authjs.session-token"));
+    const match = setCookie?.match(AUTH_COOKIE_PATTERN)?.[1];
       
     if (!match)
       throw new Error(


### PR DESCRIPTION
I was having problems where it was fetching a completely unrelated cookie that was not the one we were looking for. This fixes the problem and makes it more reliable