### PR TITLE
add .ts to the list of shadcn ui exports

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,10 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./*": "./src/*.tsx"
+    "./*": [
+      "./src/*.tsx",
+      "./src/*.ts"
+    ]
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
The shadcn also contains ui files with the .ts extension, such as use-toast.ts.
An error shows if ".ts" is not added.

![lint-error](https://github.com/t3-oss/create-t3-turbo/assets/17017234/ad8d96b5-e473-452b-a3bc-6b37bef85d19)
