### PR TITLE
chore: update eslint and typescript in package.json.hbs

### DIFF
--- a/turbo/generators/templates/package.json.hbs
+++ b/turbo/generators/templates/package.json.hbs
@@ -17,9 +17,9 @@
     "@acme/eslint-config": "workspace:*",
     "@acme/prettier-config": "workspace:*",
     "@acme/tsconfig": "workspace:*",
-    "eslint": "^9.0.0",
+    "eslint": "^9.2.0",
     "prettier": "^3.2.5",
-    "typescript": "^5.4.3"
+    "typescript": "^5.4.5"
   },
   "prettier": "@acme/prettier-config"
 }


### PR DESCRIPTION
Generated packages are on older versions of eslint and typescript, this PR updates the dependencies in the template file to be in line with the rest of the repo