### PR TITLE
feat: use parsers for .hbs files

### DIFF
--- a/tooling/prettier/index.js
+++ b/tooling/prettier/index.js
@@ -31,6 +31,20 @@ const config = {
   ],
   importOrderParserPlugins: ["typescript", "jsx", "decorators-legacy"],
   importOrderTypeScriptVersion: "4.4.0",
+  overrides: [
+    {
+      files: "*.json.hbs",
+      options: {
+        parser: "json",
+      },
+    },
+    {
+      files: "*.js.hbs",
+      options: {
+        parser: "babel",
+      },
+    },
+  ],
 };
 
 export default config;


### PR DESCRIPTION
Fixes #1052 by adding overrides to use JSON and babel parsers for `*.json.hbs` and `*.js.hbs` files. If this is too complex of a solution we can simply ignore the files from prettier