### PR TITLE
feat: get renovate to update .hbs file

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,5 +9,8 @@
   ],
   "updateInternalDeps": true,
   "rangeStrategy": "bump",
-  "automerge": true
+  "automerge": true,
+  "npm": {
+    "fileMatch": ["(^|/)package\\.json$", "(^|/)package\\.json\\.hbs$"]
+  }
 }


### PR DESCRIPTION
Update the `renovate.json` file to extend the files matched by the npm module to include `package.json.hbs` by following https://docs.renovatebot.com/modules/manager/#file-matching

Note that I have not tested this since I don't have renovate set up on my fork, but since the `package.json.hbs` file is a valid `package.json` file I believe this should work.