### PR TITLE
Update pnpm/action-setup from v2 to v4

### DIFF
--- a/tooling/github/setup/action.yml
+++ b/tooling/github/setup/action.yml
@@ -4,7 +4,7 @@ description: "Common setup steps for Actions"
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v2
+    - uses: pnpm/action-setup@v4
     - uses: actions/setup-node@v4
       with:
         node-version: 20


### PR DESCRIPTION
I was getting the following warnings in my project's GitHub Actions:

<img width="856" alt="Screenshot 2024-06-20 at 23 12 40" src="https://github.com/t3-oss/create-t3-turbo/assets/979600/1e441b2d-e1ca-4ba5-9619-212f1f6f447a">

I traced it to `pnpm/action-setup` which currently is set to v2 but the [documentation](https://github.com/marketplace/actions/setup-pnpm) show v4 as the latest.