### PR TITLE
Use pnpm catalogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "engines": {
     "node": ">=20.12.0"
   },
-  "packageManager": "pnpm@9.2.0",
+  "packageManager": "pnpm@9.5.0",
   "scripts": {
     "build": "turbo run build",
     "clean": "git clean -xdf node_modules",


### PR DESCRIPTION
Blocked by: the stable release of pnpm 9.5.0.

Catalogs (RFC: https://github.com/pnpm/rfcs/pull/1) are now available in `pnpm@9.5.0-beta.0`.

I think this is a very useful feature for create-t3-turbo because it reduces duplication in the codebase.

I believe this is a good default – most of the time, I don't want to use different versions of prettier across the codebase – and it's very easy to opt out for specific packages.