### PR TITLE
VSC Prettier extension: ignore files from .gitignore

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
     { "pattern": "packages/*/" },
     { "pattern": "tooling/*/" }
   ],
+  "prettier.ignorePath": ".gitignore",
   "tailwindCSS.experimental.classRegex": [
     ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
     ["cx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]


### PR DESCRIPTION
When I was fixing conflict in `pnpm-lock.yaml` it got formatted unnecessarily. By default extension ignores files from `.prettierignore`, but we use gitignore.