### PR TITLE
chore: use `turbo watch` instead of `tsc --watch`

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -6,14 +6,14 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "default": "./src/index.ts"
+      "default": "./dist/index.js"
     }
   },
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
     "clean": "rm -rf .turbo dist node_modules",
+    "dev": "tsc",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "@acme/tsconfig/base.json",
-  "compilerOptions": {
-    "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"
-  },
+  "compilerOptions": {},
   "include": ["src", "*.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -6,21 +6,21 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "default": "./src/index.ts"
+      "default": "./dist/index.js"
     },
     "./client": {
       "types": "./dist/client.d.ts",
-      "default": "./src/client.ts"
+      "default": "./dist/client.js"
     },
     "./schema": {
       "types": "./dist/schema.d.ts",
-      "default": "./src/schema.ts"
+      "default": "./dist/schema.js"
     }
   },
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
+    "dev": "tsc",
     "clean": "rm -rf .turbo dist node_modules",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint",

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "@acme/tsconfig/internal-package.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"
-  },
+  "compilerOptions": {},
   "include": ["src"],
   "exclude": ["node_modules"]
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,15 +4,20 @@
   "version": "0.1.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./*": [
-      "./src/*.tsx",
-      "./src/*.ts"
-    ]
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    },
+    "./*": {
+      "types": "./dist/src/*.d.ts",
+      "default": "./dist/src/*.jsx"
+    }
   },
   "license": "MIT",
   "scripts": {
-    "clean": "rm -rf .turbo node_modules",
+    "build": "tsc",
+    "clean": "rm -rf .turbo dist node_modules",
+    "dev": "tsc",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "ES2022"],
     "jsx": "preserve",
-    "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"
+    "rootDir": "."
   },
   "include": ["*.ts", "src"],
   "exclude": ["node_modules"]

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -12,8 +12,8 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
     "clean": "rm -rf .turbo dist node_modules",
+    "dev": "tsc",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"

--- a/packages/validators/tsconfig.json
+++ b/packages/validators/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "@acme/tsconfig/internal-package.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"
-  },
+  "compilerOptions": {},
   "include": ["*.ts", "src"],
   "exclude": ["node_modules"]
 }

--- a/tooling/typescript/base.json
+++ b/tooling/typescript/base.json
@@ -14,6 +14,7 @@
     /** Keep TSC performant in monorepos */
     "incremental": true,
     "disableSourceOfProjectReferenceRedirect": true,
+    "tsBuildInfoFile": "${configDir}/node_modules/.cache/tsbuildinfo.json",
 
     /** Strictness */
     "strict": true,

--- a/tooling/typescript/internal-package.json
+++ b/tooling/typescript/internal-package.json
@@ -6,6 +6,6 @@
     "declaration": true,
     "declarationMap": true,
     "noEmit": false,
-    "emitDeclarationOnly": true
+    "outDir": "${configDir}/dist"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -13,11 +13,11 @@
         "next-env.d.ts",
         ".expo/**",
         ".output/**",
-        ".vercel/output/**"
+        ".vercel/output/**",
+        "node_modules/.cache/tsbuildinfo.json"
       ]
     },
     "dev": {
-      "persistent": true,
       "cache": false
     },
     "format": {

--- a/turbo/generators/templates/package.json.hbs
+++ b/turbo/generators/templates/package.json.hbs
@@ -8,7 +8,9 @@
   },
   "license": "MIT",
   "scripts": {
+    "build": "tsc",
     "clean": "rm -rf .turbo node_modules",
+    "dev": "tsc",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint",
     "typecheck": "tsc --noEmit"

--- a/turbo/generators/templates/tsconfig.json.hbs
+++ b/turbo/generators/templates/tsconfig.json.hbs
@@ -1,8 +1,6 @@
 {
-  "extends": "@acme/tsconfig/base.json",
-  "compilerOptions": {
-    "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"
-  },
+  "extends": "@acme/tsconfig/internal-package.json",
+  "compilerOptions": {},
   "include": ["*.ts", "src"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
less watchers should be more "easy" on the dev machine running them :)

- is there some way to not have to duplicate `build` and `dev` scripts?
