### PR TITLE
fix: expo router main file

### DIFF
--- a/apps/expo/index.ts
+++ b/apps/expo/index.ts
@@ -1,0 +1,1 @@
+import "expo-router/entry";

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -2,7 +2,7 @@
   "name": "@acme/expo",
   "version": "0.1.0",
   "private": true,
-  "main": "expo-router/entry",
+  "main": "index.ts",
   "scripts": {
     "clean": "git clean -xdf .expo .turbo node_modules",
     "dev": "expo start",


### PR DESCRIPTION
This PR is for the problem of not finding the correct path for the expo-router on android devices when using monorepo.