### PR TITLE
update eas build tools versions

### DIFF
--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -4,7 +4,8 @@
   },
   "build": {
     "base": {
-      "node": "18.16.1",
+      "node": "20.15.0",
+      "pnpm": "9.6.0",
       "ios": {
         "resourceClass": "m-medium"
       }


### PR DESCRIPTION
The current EAS build environment uses Node.js v18.16.1 and pnpm v9.3.0. However, this monorepo now utilizes pnpm's catalog feature, which was [introduced in pnpm v9.5.0](https://pnpm.io/catalogs). 

Set pnpm to 9.6.0 to ensure catalog functionality support on EAS builds and Node.js version to match the one in the repo.
Relevant eas.json file [`apps/expo/eas.json`](https://github.com/t3-oss/create-t3-turbo/blob/main/apps/expo/eas.json#L7)

Screenshot of the error i recently encountered on eas:
![image](https://github.com/user-attachments/assets/5da5bbde-b12c-40cb-b861-841ba37b7601)
