### PR TITLE
Enable link-workspace-packages in npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 node-linker=hoisted
+link-workspace-packages=true


### PR DESCRIPTION
Since pnpm [v9](https://github.com/pnpm/pnpm/releases/tag/v9.0.0) was released [link-workspace-packages](https://pnpm.io/npmrc#link-workspace-packages) has been disabled by default. This means that if you were to run a command like:

`pnpm i @acme/validators -F @acme/auth-proxy`

 it would fail with this error:

`@acme/validators is not in the npm registry, or you have no permission to fetch it.`.

Turning link-workspace-packages back on resolves this