### PR TITLE
fix: Add a flag to package gen typecheck script

### DIFF
--- a/turbo/generators/templates/package.json.hbs
+++ b/turbo/generators/templates/package.json.hbs
@@ -13,7 +13,7 @@
     "dev": "tsc",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "devDependencies": {
     "@acme/eslint-config": "workspace:*",


### PR DESCRIPTION
Since package default now emits declaration files by default we need to disable it on typecheck.