### PR TITLE
fix: Continue executing `dev` when one task fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean:workspaces": "turbo run clean",
     "db:push": "turbo -F @acme/db push",
     "db:studio": "turbo -F @acme/db studio",
-    "dev": "turbo watch dev",
+    "dev": "turbo watch dev --continue",
     "dev:next": "turbo watch dev -F @acme/nextjs...",
     "format": "turbo run format --continue -- --cache --cache-location .cache/.prettiercache",
     "format:fix": "turbo run format --continue -- --write --cache --cache-location .cache/.prettiercache",


### PR DESCRIPTION
Bug was introduced in #1115