### PR TITLE
Update package.json

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,8 +11,8 @@
     "./*": {
       "types": "./dist/src/*.d.ts",
       "default": [
-        "./src/*.ts",
-        "./src/*.tsx"
+        "./src/*.tsx",
+        "./src/*.ts"
       ]
     }
   },


### PR DESCRIPTION
For some reason, Next.js will try this list in order, and the first valid result will be used; if we use `*.ts` first, next.js will error it out.