### PR TITLE
fix: slice token bearer prefix in invalidate function

### DIFF
--- a/packages/auth/src/config.ts
+++ b/packages/auth/src/config.ts
@@ -71,5 +71,6 @@ export const validateToken = async (
 };
 
 export const invalidateSessionToken = async (token: string) => {
-  await adapter.deleteSession?.(token);
+  const sessionToken = token.slice("Bearer ".length);
+  await adapter.deleteSession?.(sessionToken);
 };


### PR DESCRIPTION
The parameter "token", its value contains prefix "Bearer ". This will cause error.