### PR TITLE
feat: Update action.yml to use .nvmrc instead of hardcoded node version

### DIFF
--- a/tooling/github/setup/action.yml
+++ b/tooling/github/setup/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: pnpm/action-setup@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version-file: ".nvmrc"
         cache: "pnpm"
 
     - shell: bash


### PR DESCRIPTION
Using this on my current setup, since it makes more sense. The .nvmrc file by default specifies 20.16, gh actions is using 20.17.