### PR TITLE
Improve dev script

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,7 @@
       "outputs": [".cache/tsbuildinfo.json", "dist/**"]
     },
     "dev": {
+      "dependsOn": ["^dev"],
       "cache": false,
       "persistent": false
     },


### PR DESCRIPTION
This PR enhances the dev script by adding a dependency on the `dev` task.

Before this change, if I edited something for example in the database schema, it would only trigger changes in `@acme/db`, and it would not trigger tsc for `@acme/api`. You would need to manually trigger it with another process (eg. `pnpm build -F @acme/api...`). Now, any changes to a package will correctly cascade down all tscs for packages that depend on it 