### PR TITLE
remove confusing links from github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,0 @@
-contact_links:
-  - name: Ask a question
-    url: https://github.com/t3-oss/create-t3-turbo/discussions
-    about: Ask questions and discuss with other community members
-  - name: Feature request
-    url: https://github.com/t3-oss/create-t3-turbo/discussions/new?category=ideas
-    about: Feature requests should be opened as discussions


### PR DESCRIPTION
I've been using this template for a while for a little project I'm working on. I had an idea for a feature that I didn't want to forget, so I figured I'd quickly make an issue on Github. I went to the issues tab of **my own repository**, clicked new issue, clicked the feature request template (or so I thought), and filled out the form. 

Turns out, I created a discussion post (#1276) on **this repository** without realizing it. It's because of a .github config file that uses hard coded links back to this repository. There's no mention in the README about it, so I didn't know to change it when I made my copy of the template. I don't seem to be the only one confused by this. In fact, the discussion post created just before mine was caused by the same weird link (#1275). 

Removing this file should resolve that. Obviously it will also remove these two links from this repo, but (at least from my perspective) that isn't a huge loss. **This does not remove the discussion templates themselves. Only the links to them from the new issue screen.**
![2025-01-03 at 22 11 33@2x](https://github.com/user-attachments/assets/793ebd97-c20a-4863-ae4f-7d8529801204)