### PR TITLE
fix: disable edge runtime by default to enable windows development

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,7 @@ tooling
 ## Quick Start
 
 > **Note**
-> Due to a [bug](https://github.com/vercel/next.js/issues/53562) affecting windows development, the edge runtime is currently disabled by default. If your environment supports it, you can enable the edge runtime by adding the line `export const runtime = "edge";` [to all pages and api routes](https://github.com/t3-oss/create-t3-turbo/issues/634#issuecomment-1730240214). The pages and routes included in this template include this line commented out, for illustration purposes.
-
-> **Note**
-> The [db](./packages/db) package is preconfigured to use Supabase and is **edge-bound** with the [Vercel Postgres](https://github.com/vercel/storage/tree/main/packages/postgres) driver. If you're using something else, make the necessary modifications to the [schema](./packages/db/src/schema.ts) as well as the [client](./packages/db/src/index.ts) and the [drizzle config](./packages/db/drizzle.config.ts).
+> The [db](./packages/db) package is preconfigured to use Supabase and is **edge-bound** with the [Vercel Postgres](https://github.com/vercel/storage/tree/main/packages/postgres) driver. If you're using something else, make the necessary modifications to the [schema](./packages/db/src/schema.ts) as well as the [client](./packages/db/src/index.ts) and the [drizzle config](./packages/db/drizzle.config.ts). If you want to switch to non-edge database driver, remove `export const runtime = "edge";` [from all pages and api routes](https://github.com/t3-oss/create-t3-turbo/issues/634#issuecomment-1730240214).
 
 To get it running, follow the steps below:
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ tooling
 ## Quick Start
 
 > **Note**
-> The [db](./packages/db) package is preconfigured to use Supabase and is **edge-bound** with the [Vercel Postgres](https://github.com/vercel/storage/tree/main/packages/postgres) driver. If you're using something else, make the necessary modifications to the [schema](./packages/db/src/schema.ts) as well as the [client](./packages/db/src/index.ts) and the [drizzle config](./packages/db/drizzle.config.ts). If you want to switch to non-edge database driver, remove `export const runtime = "edge";` [from all pages and api routes](https://github.com/t3-oss/create-t3-turbo/issues/634#issuecomment-1730240214).
+> Due to a [bug](https://github.com/vercel/next.js/issues/53562) affecting windows development, the edge runtime is currently disabled by default. If your environment supports it, you can enable the edge runtime by adding the line `export const runtime = "edge";` [to all pages and api routes](https://github.com/t3-oss/create-t3-turbo/issues/634#issuecomment-1730240214). The pages and routes included in this template include this line commented out, for illustration purposes.
+
+> **Note**
+> The [db](./packages/db) package is preconfigured to use Supabase and is **edge-bound** with the [Vercel Postgres](https://github.com/vercel/storage/tree/main/packages/postgres) driver. If you're using something else, make the necessary modifications to the [schema](./packages/db/src/schema.ts) as well as the [client](./packages/db/src/index.ts) and the [drizzle config](./packages/db/drizzle.config.ts).
 
 To get it running, follow the steps below:
 

--- a/apps/nextjs/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/nextjs/src/app/api/auth/[...nextauth]/route.ts
@@ -3,8 +3,6 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { handlers, isSecureContext } from "@acme/auth";
 
-// Uncomment this line to enable edge runtime if your environment supports it
-// export const runtime = "edge";
 
 const EXPO_COOKIE_NAME = "__acme-expo-redirect-state";
 const AUTH_COOKIE_PATTERN = /authjs\.session-token=([^;]+)/;

--- a/apps/nextjs/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/nextjs/src/app/api/auth/[...nextauth]/route.ts
@@ -3,7 +3,6 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { handlers, isSecureContext } from "@acme/auth";
 
-
 const EXPO_COOKIE_NAME = "__acme-expo-redirect-state";
 const AUTH_COOKIE_PATTERN = /authjs\.session-token=([^;]+)/;
 

--- a/apps/nextjs/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/nextjs/src/app/api/auth/[...nextauth]/route.ts
@@ -3,7 +3,8 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { handlers, isSecureContext } from "@acme/auth";
 
-export const runtime = "edge";
+// Uncomment this line to enable edge runtime if your environment supports it
+// export const runtime = "edge";
 
 const EXPO_COOKIE_NAME = "__acme-expo-redirect-state";
 const AUTH_COOKIE_PATTERN = /authjs\.session-token=([^;]+)/;

--- a/apps/nextjs/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/nextjs/src/app/api/trpc/[trpc]/route.ts
@@ -3,7 +3,6 @@ import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { appRouter, createTRPCContext } from "@acme/api";
 import { auth } from "@acme/auth";
 
-
 /**
  * Configure basic CORS headers
  * You should extend this to match your needs

--- a/apps/nextjs/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/nextjs/src/app/api/trpc/[trpc]/route.ts
@@ -3,7 +3,8 @@ import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { appRouter, createTRPCContext } from "@acme/api";
 import { auth } from "@acme/auth";
 
-export const runtime = "edge";
+// Uncomment this line to enable edge runtime if your environment supports it
+// export const runtime = "edge";
 
 /**
  * Configure basic CORS headers

--- a/apps/nextjs/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/nextjs/src/app/api/trpc/[trpc]/route.ts
@@ -3,8 +3,6 @@ import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { appRouter, createTRPCContext } from "@acme/api";
 import { auth } from "@acme/auth";
 
-// Uncomment this line to enable edge runtime if your environment supports it
-// export const runtime = "edge";
 
 /**
  * Configure basic CORS headers

--- a/apps/nextjs/src/app/page.tsx
+++ b/apps/nextjs/src/app/page.tsx
@@ -8,7 +8,8 @@ import {
   PostList,
 } from "./_components/posts";
 
-export const runtime = "edge";
+// Uncomment this line to enable edge runtime if your environment supports it
+// export const runtime = "edge";
 
 export default function HomePage() {
   // You can await this here if you don't want to show Suspense fallback below

--- a/apps/nextjs/src/app/page.tsx
+++ b/apps/nextjs/src/app/page.tsx
@@ -8,7 +8,6 @@ import {
   PostList,
 } from "./_components/posts";
 
-
 export default function HomePage() {
   // You can await this here if you don't want to show Suspense fallback below
   void api.post.all.prefetch();

--- a/apps/nextjs/src/app/page.tsx
+++ b/apps/nextjs/src/app/page.tsx
@@ -8,8 +8,6 @@ import {
   PostList,
 } from "./_components/posts";
 
-// Uncomment this line to enable edge runtime if your environment supports it
-// export const runtime = "edge";
 
 export default function HomePage() {
   // You can await this here if you don't want to show Suspense fallback below


### PR DESCRIPTION
* Because of the bug described [here](https://github.com/vercel/next.js/issues/53562), I updated the line that exports runtime to check if the process is being run on Windows and select the nodejs runtime in that case.
* I also updated the README to explain this, since it could otherwise be confusing, and my changes should be removed if that bug is fixed.
* fixes #1280 