### PR TITLE
fix: use correct node and pnpm versions in eas.json

### DIFF
--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -4,8 +4,8 @@
   },
   "build": {
     "base": {
-      "node": "20.16.0",
-      "pnpm": "9.7.0",
+      "node": "20.18.1",
+      "pnpm": "9.14.2",
       "ios": {
         "resourceClass": "m-medium"
       }


### PR DESCRIPTION
The expo app's `eas.json` file specify `node` and `pnpm` versions that are incompatible with the engines specified in the root `package.json` file.

This is causing EAS builds to fail with the following error:

```
Running "pnpm install --no-frozen-lockfile" in /home/expo/workingdir/build directory

ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your pnpm version is incompatible with "/home/expo/workingdir/build".

Expected version: ^9.14.2

Got: 9.7.0

This is happening because the package's manifest has an engines.pnpm field specified.

To fix this issue, install the required pnpm version globally.

To install the latest version of pnpm, run "pnpm i -g pnpm".

To check your pnpm version, run "pnpm -v".

Your Node version is incompatible with "/home/expo/workingdir/build".

Expected version: >=20.18.1
```

This PR just updates the versions used in `eas.json` to match what is required by the monorepo itself.