### PR TITLE
Update Turborepo docs domain.

### DIFF
--- a/apps/expo/metro.config.js
+++ b/apps/expo/metro.config.js
@@ -22,7 +22,7 @@ module.exports = config;
  * Move the Metro cache to the `.cache/metro` folder.
  * If you have any environment variables, you can configure Turborepo to invalidate it when needed.
  *
- * @see https://turbo.build/repo/docs/reference/configuration#env
+ * @see https://turborepo.com/docs/reference/configuration#env
  * @param {import('expo/metro-config').MetroConfig} config
  * @returns {import('expo/metro-config').MetroConfig}
  */


### PR DESCRIPTION
We updated the domain for the Turborepo documentation, and am trying to make sure links get updated where I can find them.

Thanks for using Turborepo!