### PR TITLE
refactor: better-auth initialization to use auth config for cli support

### DIFF
--- a/packages/auth/env.ts
+++ b/packages/auth/env.ts
@@ -17,3 +17,5 @@ export function authEnv() {
       !!process.env.CI || process.env.npm_lifecycle_event === "lint",
   });
 }
+
+export const env = authEnv();

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,47 +1,22 @@
-import type { BetterAuthOptions } from "better-auth";
-import { expo } from "@better-auth/expo";
 import { betterAuth } from "better-auth";
-import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { oAuthProxy } from "better-auth/plugins";
 
-import { db } from "@acme/db/client";
+import { env } from "../env";
+import { AuthInitOptions, sharedAuthConfig } from "./shared";
 
-export function initAuth(options: {
-  baseUrl: string;
-  productionUrl: string;
-  secret: string | undefined;
-
-  discordClientId: string;
-  discordClientSecret: string;
-}) {
-  const config = {
-    database: drizzleAdapter(db, {
-      provider: "pg",
-    }),
-    baseURL: options.baseUrl,
-    secret: options.secret,
-    plugins: [
-      oAuthProxy({
-        /**
-         * Auto-inference blocked by https://github.com/better-auth/better-auth/pull/2891
-         */
-        currentURL: options.baseUrl,
-        productionURL: options.productionUrl,
-      }),
-      expo(),
-    ],
-    socialProviders: {
-      discord: {
-        clientId: options.discordClientId,
-        clientSecret: options.discordClientSecret,
-        redirectURI: `${options.productionUrl}/api/auth/callback/discord`,
-      },
-    },
-    trustedOrigins: ["expo://"],
-  } satisfies BetterAuthOptions;
-
-  return betterAuth(config);
+export function initAuth(options: AuthInitOptions) {
+  return betterAuth(sharedAuthConfig(options));
 }
 
 export type Auth = ReturnType<typeof initAuth>;
 export type Session = Auth["$Infer"]["Session"];
+
+// Default export better-auth config for CLI
+export const auth = betterAuth(
+  sharedAuthConfig({
+    baseUrl: "http://localhost:3000",
+    productionUrl: "https://myapp.com",
+    secret: env.AUTH_SECRET,
+    discordClientId: env.AUTH_DISCORD_ID,
+    discordClientSecret: env.AUTH_DISCORD_SECRET,
+  }),
+);

--- a/packages/auth/src/shared.ts
+++ b/packages/auth/src/shared.ts
@@ -1,0 +1,43 @@
+import type { BetterAuthOptions } from "better-auth";
+import { expo } from "@better-auth/expo";
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { oAuthProxy } from "better-auth/plugins";
+
+import { db } from "@acme/db/client";
+
+export interface AuthInitOptions {
+  baseUrl: string;
+  productionUrl: string;
+  secret: string | undefined;
+
+  discordClientId: string;
+  discordClientSecret: string;
+}
+
+export const sharedAuthConfig = (
+  options: AuthInitOptions,
+): BetterAuthOptions => ({
+  database: drizzleAdapter(db, {
+    provider: "pg",
+  }),
+  baseURL: options.baseUrl,
+  secret: options.secret,
+  plugins: [
+    oAuthProxy({
+      /**
+       * Auto-inference blocked by https://github.com/better-auth/better-auth/pull/2891
+       */
+      currentURL: options.baseUrl,
+      productionURL: options.productionUrl,
+    }),
+    expo(),
+  ],
+  socialProviders: {
+    discord: {
+      clientId: options.discordClientId,
+      clientSecret: options.discordClientSecret,
+      redirectURI: `${options.productionUrl}/api/auth/callback/discord`,
+    },
+  },
+  trustedOrigins: ["expo://"],
+});


### PR DESCRIPTION
This PR separates the config into shared config and separately exports the better-auth config for outside apps and the CLI. This is not an ideal solution, I know but it worked for me, so I am trying to fix it temporarily

Resolves #1375 