### PR TITLE
Simplify ESLint configuration

### DIFF
--- a/apps/expo/eslint.config.mjs
+++ b/apps/expo/eslint.config.mjs
@@ -1,11 +1,9 @@
-import baseConfig from "@acme/eslint-config/base";
 import reactConfig from "@acme/eslint-config/react";
 
 /** @type {import('typescript-eslint').Config} */
 export default [
   {
-    ignores: [".expo/**", "expo-plugins/**"],
+    ignores: ["expo-plugins/**"],
   },
-  ...baseConfig,
   ...reactConfig,
 ];

--- a/apps/nextjs/eslint.config.js
+++ b/apps/nextjs/eslint.config.js
@@ -1,14 +1,5 @@
-import baseConfig, { restrictEnvAccess } from "@acme/eslint-config/base";
+import { restrictEnvAccess } from "@acme/eslint-config/base";
 import nextjsConfig from "@acme/eslint-config/nextjs";
-import reactConfig from "@acme/eslint-config/react";
 
 /** @type {import('typescript-eslint').Config} */
-export default [
-  {
-    ignores: [".next/**"],
-  },
-  ...baseConfig,
-  ...reactConfig,
-  ...nextjsConfig,
-  ...restrictEnvAccess,
-];
+export default [...nextjsConfig, ...restrictEnvAccess];

--- a/packages/api/eslint.config.js
+++ b/packages/api/eslint.config.js
@@ -1,9 +1,4 @@
 import baseConfig from "@acme/eslint-config/base";
 
 /** @type {import('typescript-eslint').Config} */
-export default [
-  {
-    ignores: ["dist/**"],
-  },
-  ...baseConfig,
-];
+export default baseConfig;

--- a/packages/auth/eslint.config.js
+++ b/packages/auth/eslint.config.js
@@ -1,10 +1,4 @@
 import baseConfig, { restrictEnvAccess } from "@acme/eslint-config/base";
 
 /** @type {import('typescript-eslint').Config} */
-export default [
-  {
-    ignores: [],
-  },
-  ...baseConfig,
-  ...restrictEnvAccess,
-];
+export default [...baseConfig, ...restrictEnvAccess];

--- a/packages/db/eslint.config.js
+++ b/packages/db/eslint.config.js
@@ -1,9 +1,4 @@
 import baseConfig from "@acme/eslint-config/base";
 
 /** @type {import('typescript-eslint').Config} */
-export default [
-  {
-    ignores: ["dist/**"],
-  },
-  ...baseConfig,
-];
+export default baseConfig;

--- a/packages/ui/eslint.config.js
+++ b/packages/ui/eslint.config.js
@@ -2,10 +2,4 @@ import baseConfig from "@acme/eslint-config/base";
 import reactConfig from "@acme/eslint-config/react";
 
 /** @type {import('typescript-eslint').Config} */
-export default [
-  {
-    ignores: ["dist/**"],
-  },
-  ...baseConfig,
-  ...reactConfig,
-];
+export default reactConfig;

--- a/packages/validators/eslint.config.js
+++ b/packages/validators/eslint.config.js
@@ -1,9 +1,4 @@
 import baseConfig from "@acme/eslint-config/base";
 
 /** @type {import('typescript-eslint').Config} */
-export default [
-  {
-    ignores: ["dist/**"],
-  },
-  ...baseConfig,
-];
+export default baseConfig;

--- a/tooling/eslint/nextjs.js
+++ b/tooling/eslint/nextjs.js
@@ -1,7 +1,10 @@
 import nextPlugin from "@next/eslint-plugin-next";
 
+import reactConfig from "./react.js";
+
 /** @type {Awaited<import('typescript-eslint').Config>} */
 export default [
+  ...reactConfig,
   {
     files: ["**/*.ts", "**/*.tsx"],
     plugins: {

--- a/tooling/eslint/react.js
+++ b/tooling/eslint/react.js
@@ -1,8 +1,11 @@
 import reactPlugin from "eslint-plugin-react";
 import * as reactHooks from "eslint-plugin-react-hooks";
 
+import baseConfig from "./base.js";
+
 /** @type {Awaited<import('typescript-eslint').Config>} */
 export default [
+  ...baseConfig,
   reactHooks.configs.recommended,
   {
     files: ["**/*.ts", "**/*.tsx"],

--- a/turbo/generators/templates/eslint.config.js.hbs
+++ b/turbo/generators/templates/eslint.config.js.hbs
@@ -1,9 +1,4 @@
 import baseConfig from "@acme/eslint-config/base";
 
 /** @type {import('typescript-eslint').Config} */
-export default [
-  {
-    ignores: [],
-  },
-  ...baseConfig,
-];
+export default baseConfig;


### PR DESCRIPTION
Idea here is to simplify eslint usage:
base -> react -> nextJs

Then, the user can just select just one of these three for their package's lint rules. Much simpler.

I also removed some redundant ignores, as they are listed in the .gitignore and `base.js`uses `includeIgnoreFile(path.join(import.meta.dirname, "../../.gitignore"))`