### PR TITLE
chore: use url() method directly

### DIFF
--- a/apps/nextjs/src/env.ts
+++ b/apps/nextjs/src/env.ts
@@ -16,7 +16,7 @@ export const env = createEnv({
    * This way you can ensure the app isn't built with invalid env vars.
    */
   server: {
-    POSTGRES_URL: z.string().url(),
+    POSTGRES_URL: z.url(),
   },
 
   /**


### PR DESCRIPTION
Not anything big, just looked ugly

Replaced deprecated `z.string().url()` with `z.url()`
