### PR TITLE
Add dotenv-cli dependency to package.json

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -38,7 +38,6 @@
     "@types/node": "^22.18.10",
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19",
-    "dotenv-cli": "^10.0.0",
     "eslint": "catalog:",
     "jiti": "^2.5.1",
     "prettier": "catalog:",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@acme/prettier-config": "workspace:*",
     "@turbo/gen": "^2.5.8",
+    "dotenv-cli": "^10.0.0",
     "prettier": "catalog:",
     "turbo": "^2.5.8",
     "typescript": "catalog:"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -32,7 +32,6 @@
     "@acme/tsconfig": "workspace:*",
     "@better-auth/cli": "1.3.27",
     "@types/react": "catalog:react19",
-    "dotenv-cli": "^10.0.0",
     "eslint": "catalog:",
     "prettier": "catalog:",
     "typescript": "catalog:"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -38,7 +38,6 @@
     "@acme/eslint-config": "workspace:*",
     "@acme/prettier-config": "workspace:*",
     "@acme/tsconfig": "workspace:*",
-    "dotenv-cli": "^10.0.0",
     "drizzle-kit": "^0.31.5",
     "eslint": "catalog:",
     "prettier": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@turbo/gen':
         specifier: ^2.5.8
         version: 2.5.8(@types/node@24.7.2)(typescript@5.9.3)
+      dotenv-cli:
+        specifier: ^10.0.0
+        version: 10.0.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -266,9 +269,6 @@ importers:
       '@types/react-dom':
         specifier: catalog:react19
         version: 19.1.9(@types/react@19.1.12)
-      dotenv-cli:
-        specifier: ^10.0.0
-        version: 10.0.0
       eslint:
         specifier: 'catalog:'
         version: 9.37.0(jiti@2.6.1)
@@ -404,9 +404,6 @@ importers:
       '@acme/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/typescript
-      dotenv-cli:
-        specifier: ^10.0.0
-        version: 10.0.0
       drizzle-kit:
         specifier: ^0.31.5
         version: 0.31.5
@@ -8972,7 +8969,7 @@ snapshots:
       metro-babel-transformer: 0.83.1
       metro-cache: 0.83.1
       metro-cache-key: 0.83.1
-      metro-config: 0.83.1(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      metro-config: 0.83.1(bufferutil@4.0.8)
       metro-core: 0.83.1
       metro-file-map: 0.83.1
       metro-resolver: 0.83.1
@@ -10368,7 +10365,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.83.3(bufferutil@4.0.8)(utf-8-validate@6.0.4)
-      metro-config: 0.83.3(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      metro-config: 0.83.3(bufferutil@4.0.8)
       metro-core: 0.83.3
       semver: 7.7.3
     transitivePeerDependencies:
@@ -13689,42 +13686,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro-config@0.83.1(bufferutil@4.0.8)(utf-8-validate@6.0.4):
-    dependencies:
-      connect: 3.7.0
-      cosmiconfig: 5.2.1
-      flow-enums-runtime: 0.0.6
-      jest-validate: 29.7.0
-      metro: 0.83.1(bufferutil@4.0.8)(utf-8-validate@6.0.4)
-      metro-cache: 0.83.1
-      metro-core: 0.83.1
-      metro-runtime: 0.83.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   metro-config@0.83.3(bufferutil@4.0.8):
     dependencies:
       connect: 3.7.0
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
       metro: 0.83.3(bufferutil@4.0.8)
-      metro-cache: 0.83.3
-      metro-core: 0.83.3
-      metro-runtime: 0.83.3
-      yaml: 2.8.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro-config@0.83.3(bufferutil@4.0.8)(utf-8-validate@6.0.4):
-    dependencies:
-      connect: 3.7.0
-      flow-enums-runtime: 0.0.6
-      jest-validate: 29.7.0
-      metro: 0.83.3(bufferutil@4.0.8)(utf-8-validate@6.0.4)
       metro-cache: 0.83.3
       metro-core: 0.83.3
       metro-runtime: 0.83.3
@@ -14029,7 +13996,7 @@ snapshots:
       metro-babel-transformer: 0.83.1
       metro-cache: 0.83.1
       metro-cache-key: 0.83.1
-      metro-config: 0.83.1(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      metro-config: 0.83.1(bufferutil@4.0.8)
       metro-core: 0.83.1
       metro-file-map: 0.83.1
       metro-resolver: 0.83.1
@@ -14123,7 +14090,7 @@ snapshots:
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
-      metro-config: 0.83.3(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      metro-config: 0.83.3(bufferutil@4.0.8)
       metro-core: 0.83.3
       metro-file-map: 0.83.3
       metro-resolver: 0.83.3


### PR DESCRIPTION
Lack of Dotenv Caused Generate command to fail
resolves #1429 

this is not meant to be an [update readme](https://youtu.be/IrrOHBqq7oU) PR it's just that i reinited my project and it kept on failing to generate the auth schema , i just found that the cause was the lack of the dot-env cli package in the auth package :D
