### PR TITLE
fix: eslint added flag for ts

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -22,7 +22,7 @@
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "dev": "tsc",
     "format": "prettier --check . --ignore-path ../../.gitignore",
-    "lint": "eslint",
+    "lint": "eslint --flag unstable_native_nodejs_ts_config",
     "push": "pnpm with-env drizzle-kit push",
     "studio": "pnpm with-env drizzle-kit studio",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",


### PR DESCRIPTION
Given that the eslint config is now a ts file, this may be necessary as in the other packages.