### PR TITLE
Clear deployment error messages when env vars are missing

### DIFF
--- a/apps/nextjs/src/env.ts
+++ b/apps/nextjs/src/env.ts
@@ -5,6 +5,13 @@ import { z } from "zod/v4";
 import { authEnv } from "@acme/auth/env";
 
 export const env = createEnv({
+  onValidationError(error) {
+    const missing = error.map((i) => (i.path ?? []).join(".")).join(", ");
+    throw new Error(
+      `❌ Missing or invalid environment variables: ${missing}\n` +
+        `   Check your .env file or Vercel project settings.`,
+    );
+  },
   extends: [authEnv(), vercel()],
   shared: {
     NODE_ENV: z


### PR DESCRIPTION
Deployment errors are confusing.

Without this change, a missing env var ends with this in Vercel runtime logs:
`⨯ Error: Failed to load static file for page: /500 ENOENT: no such file or directory ...`

With this change:
`❌ Missing or invalid environment variables: NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, NEXT_PUBLIC_POSTHOG_HOST`
"Check your .env file or Vercel project settings."

Much simpler