### PR TITLE
fix(ui): correct shadcn components.json aliases for ui package

### DIFF
--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -5,13 +5,13 @@
   "tsx": true,
   "tailwind": {
     "config": "",
-    "css": "unused.css",
+    "css": "../../tooling/tailwind/theme.css",
     "baseColor": "zinc",
     "cssVariables": true
   },
   "aliases": {
     "utils": "@acme/ui",
-    "components": "src/",
-    "ui": "src/"
+    "components": "@acme/ui",
+    "ui": "@acme/ui"
   }
 }


### PR DESCRIPTION
Fixes the shadcn `components.json` in `packages/ui` so the CLI installs components and resolves imports correctly.

Closes #1035

After this: pnpm ui-add routes new components to @acme/ui/* correctly.

