### PR TITLE
Remove deprecated eslint.runtime setting and fix dead expo docs link (Fixes #1524)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,6 @@
   },
   "editor.formatOnSave": true,
   "eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
-  "eslint.runtime": "node",
   "eslint.workingDirectories": [
     { "pattern": "apps/*/" },
     { "pattern": "packages/*/" },

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Deploying your Expo application works slightly differently compared to Next.js o
    eas build:configure
    ```
 
-3. After the initial setup, you can create your first build. You can build for Android and iOS platforms and use different [`eas.json` build profiles](https://docs.expo.dev/build-reference/eas-json) to create production builds or development, or test builds. Let's make a production build for iOS.
+3. After the initial setup, you can create your first build. You can build for Android and iOS platforms and use different [`eas.json` build profiles](https://docs.expo.dev/build/eas-json/) to create production builds or development, or test builds. Let's make a production build for iOS.
 
    ```bash
    eas build --platform ios --profile production


### PR DESCRIPTION
## What
- Removes `"eslint.runtime": "node"` from `.vscode/settings.json`. The ESLint VS Code extension deprecated that setting; recent versions warn "This setting is deprecated" on load, which is what #1524 reports.
- While in here, the README's `eas.json` build-profiles link pointed at `docs.expo.dev/build-reference/eas-json`, which returns 404 since Expo moved the page. It now points at the live `docs.expo.dev/build/eas-json/`.

## Verification
- Old expo URL returns 404, new one returns 200 (checked today).
- The remaining settings in the file have no deprecation warnings on current VS Code / ESLint / Prettier extension versions.

Fixes #1524